### PR TITLE
Resize founder image

### DIFF
--- a/src/components/sections/Founder.tsx
+++ b/src/components/sections/Founder.tsx
@@ -13,10 +13,10 @@ const Founder = () => {
         <div className="flex flex-col md:flex-row gap-12 md:items-stretch">
           <ScrollAnimation animation="fade-in" className="md:flex-1 flex justify-center">
             <div className="relative flex justify-center">
-              <img 
-                src="/Profile_Photo.jpg" 
-                alt="Alexandru Buruiana, Founder of Nego" 
-                className="max-w-md w-full h-auto object-cover md:max-h-[30rem]" />
+              <img
+                src="/Profile_Photo.jpg"
+                alt="Alexandru Buruiana, Founder of Nego"
+                className="max-w-md w-full h-auto object-cover md:max-h-[20rem]" />
               <div className="absolute -bottom-6 -right-6 bg-blue-700 text-white py-2 px-4 rounded-lg shadow-md font-medium">
                 Alexandru Buruiana, Founder
               </div>
@@ -24,7 +24,7 @@ const Founder = () => {
           </ScrollAnimation>
 
           <ScrollAnimation animation="slide-up" className="md:flex-1 flex">
-            <div className="flex flex-col justify-between h-full md:max-h-[30rem] md:overflow-auto">
+            <div className="flex flex-col justify-between h-full">
               <h3 className="text-2xl font-bold mb-4 text-navy-950">Alexandru Buruiana</h3>
               <p className="text-gray-600 mb-6">
                 Alexandru Buruiana has over five years of international negotiation experience. He began his career in the procurement department of a major Italian multinational, where he led critical supplier negotiations and cost-saving initiatives.


### PR DESCRIPTION
## Summary
- resize founder photo to 20rem max height
- remove artificial max-height from founder text container so there's no scroll

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685461c96eb4833394130210b136a431