### PR TITLE
Add full blog content display

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -11,6 +11,26 @@ const Blog: React.FC = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }, [])
 
+  const renderContent = (content: string) =>
+    content
+      .trim()
+      .split('\n\n')
+      .map((p, i) => {
+        const heading = p.match(/^\*\*(.+)\*\*$/)
+        if (heading) {
+          return (
+            <h3 key={i} className="text-lg font-semibold mt-4 mb-2">
+              {heading[1]}
+            </h3>
+          )
+        }
+        return (
+          <p key={i} className="mb-2">
+            {p}
+          </p>
+        )
+      })
+
   return (
     <section className="section">
       <div className="container">
@@ -39,7 +59,9 @@ const Blog: React.FC = () => {
                       <span>{post.readTime}</span>
                     </div>
                     <h3 className="text-xl font-bold mb-2 text-navy-950">{post.title}</h3>
-                    <p className="text-gray-600 mb-4">{post.excerpt}</p>
+                    <div className="text-gray-600 mb-4 space-y-2">
+                      {renderContent(post.content)}
+                    </div>
                   </div>
                   <div className="mt-auto">
                     <Button

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -11,6 +11,26 @@ const BlogPost: React.FC = () => {
 
   if (!post) return <Navigate to="/blog" replace />
 
+  const renderContent = (content: string) =>
+    content
+      .trim()
+      .split('\n\n')
+      .map((p, i) => {
+        const heading = p.match(/^\*\*(.+)\*\*$/)
+        if (heading) {
+          return (
+            <h3 key={i} className="text-lg font-semibold mt-4 mb-2">
+              {heading[1]}
+            </h3>
+          )
+        }
+        return (
+          <p key={i} className="mb-2">
+            {p}
+          </p>
+        )
+      })
+
   return (
     <article className="container mx-auto px-4 py-16 bg-white">
       <h1 className="text-4xl font-bold text-navy-950 mb-4">{post.title}</h1>
@@ -21,9 +41,7 @@ const BlogPost: React.FC = () => {
       </div>
       <img src={post.image} alt={post.title} className="w-full rounded-lg mb-8" />
       <div className="prose prose-lg text-gray-800">
-        {post.content.trim().split('\n\n').map((p, i) => (
-          <p key={i}>{p}</p>
-        ))}
+        {renderContent(post.content)}
       </div>
       <div className="mt-12">
         <Button href="/blog" variant="outline">← Back to Blog</Button>


### PR DESCRIPTION
## Summary
- parse basic markdown in blog posts
- show entire article text on blog listing

## Testing
- `npm run lint` *(fails: cannot find module)*
- `npx tsc -p tsconfig.json` *(fails: npm offline)*

------
https://chatgpt.com/codex/tasks/task_e_68556be853b0833395bcdba2a082ab1a