### PR TITLE
Fix blog headings

### DIFF
--- a/src/data/posts.ts
+++ b/src/data/posts.ts
@@ -21,25 +21,25 @@ const posts: Post[] = [
     author: 'Alexandru Buruiana',
     image: 'https://images.pexels.com/photos/3184339/pexels-photo-3184339.jpeg',
     excerpt: `Learn how understanding cognitive biases and human behavior can give you an edge at the bargaining table.`,
-    content: `**Introduction**  
+    content: `Introduction  
 Negotiation is as much a psychological game as it is a tactical one. Behind every offer, counteroffer, and silence lies a network of cognitive biases, emotional triggers, and unconscious patterns. Understanding the psychological forces at play helps you predict behavior and make more strategic moves.
 
-**1. Anchoring Bias**  
+1. Anchoring Bias  
 People tend to rely heavily on the first piece of information offered—the "anchor"—when making decisions. In negotiations, the initial offer often sets the tone. If you're the first to propose a number, you shape the range of discussion. If you're responding, be aware of this influence and prepare with your own research and BATNA (Best Alternative to a Negotiated Agreement).
 
-**2. Reciprocity Principle**  
+2. Reciprocity Principle  
 Humans are wired to return favors. A small concession can encourage the other party to reciprocate. This can be a powerful tactic—but be mindful not to give too much away too early, or it may backfire.
 
-**3. Framing Effects**  
+3. Framing Effects  
 The way information is presented can drastically alter its perception. Framing a proposal in terms of gains rather than losses tends to produce more favorable responses. For instance, say “you’ll gain $5,000” instead of “you won’t lose $5,000.”
 
-**4. Emotional Intelligence**  
+4. Emotional Intelligence  
 Reading emotional cues—tone of voice, posture, facial expressions—can reveal more than spoken words. High emotional intelligence allows negotiators to manage both their own reactions and the emotional climate of the conversation.
 
-**5. Building Rapport**  
+5. Building Rapport  
 Mirroring body language, maintaining eye contact, and finding common ground create trust. Negotiations built on rapport tend to lead to more sustainable, win-win outcomes.
 
-**Conclusion**  
+Conclusion  
 Mastering negotiation psychology enables you to navigate conversations with precision. By recognizing biases and leveraging human behavior patterns, you gain an edge that purely rational strategies often miss.`
   },
   {
@@ -51,25 +51,25 @@ Mastering negotiation psychology enables you to navigate conversations with prec
     author: 'Alexandru Buruiana',
     image: 'https://images.pexels.com/photos/3184292/pexels-photo-3184292.jpeg',
     excerpt: `Discover the top mistakes—like poor preparation or overconfidence—and learn simple tactics to sidestep them.`,
-    content: `**Introduction**  
+    content: `Introduction  
 Even skilled negotiators can fall into common traps that derail otherwise promising deals. Recognizing these pitfalls early allows you to sidestep them and maintain control of the negotiation process.
 
-**1. Lack of Preparation**  
+1. Lack of Preparation  
 Walking into a negotiation unprepared is one of the biggest mistakes you can make. Without knowing your objectives, limits, and alternatives, you risk accepting poor terms. Prepare by researching the other party, defining your BATNA, and outlining your ideal outcome.
 
-**2. Overconfidence**  
+2. Overconfidence  
 Confidence is an asset—until it becomes arrogance. Overestimating your leverage or underestimating the other party can lead to miscalculations. Humility combined with strategic assertiveness yields better results.
 
-**3. Focusing Only on Price**  
+3. Focusing Only on Price  
 Many negotiators get tunnel vision around price, ignoring other value-adding variables like delivery time, service levels, or payment terms. A broader perspective helps craft more balanced agreements.
 
-**4. Talking Too Much**  
+4. Talking Too Much  
 Silence is a powerful tool. Talking excessively, especially to fill awkward pauses, may lead to revealing information that weakens your position. Ask open-ended questions and listen actively.
 
-**5. Reacting Emotionally**  
+5. Reacting Emotionally  
 Negotiations can be tense. Emotional responses—whether anger, frustration, or excitement—can cloud judgment. Stay calm, take breaks if needed, and focus on facts over feelings.
 
-**Conclusion**  
+Conclusion  
 Avoiding these pitfalls won't guarantee success, but it significantly improves your odds. With awareness, preparation, and emotional discipline, you stay sharp and ahead of the curve.`
   },
   {
@@ -81,31 +81,31 @@ Avoiding these pitfalls won't guarantee success, but it significantly improves y
     author: 'Alexandru Buruiana',
     image: 'https://images.pexels.com/photos/3184183/pexels-photo-3184183.jpeg',
     excerpt: `Navigate international negotiations with respect for cultural norms, communication styles, and trust-building practices.`,
-    content: `**Introduction**  
+    content: `Introduction  
 In an increasingly globalized world, negotiators often find themselves across the table from people with vastly different cultural backgrounds. Success in these scenarios depends on more than just logic and numbers—it requires cultural intelligence, empathy, and adaptability.
 
-**1. Understanding Cultural Norms**  
+1. Understanding Cultural Norms  
 Every culture has its own rules and expectations around negotiation. For instance, while Americans may prioritize efficiency and directness, Japanese negotiators value consensus and harmony. Taking time to understand these norms prevents missteps and demonstrates respect.
 
-**2. High-Context vs. Low-Context Cultures**  
+2. High-Context vs. Low-Context Cultures  
 High-context cultures (like China or Brazil) rely heavily on implicit communication, body language, and the surrounding context. Low-context cultures (like Germany or the U.S.) favor explicit, direct communication. Adjust your communication style accordingly to avoid misunderstandings.
 
-**3. Time Perception**  
+3. Time Perception  
 In some cultures, time is rigid and schedules are sacred (monochronic), while in others, time is more fluid (polychronic). For example, punctuality may be critical in Switzerland, but less so in Latin America. Flexibility here can make or break a negotiation.
 
-**4. Attitudes Toward Hierarchy**  
+4. Attitudes Toward Hierarchy  
 In cultures with high power distance (e.g., South Korea, India), decisions may be deferred to senior leaders, and questioning authority is frowned upon. Western negotiators used to flatter hierarchies may find this challenging but should adapt their expectations.
 
-**5. Relationship vs. Task Orientation**  
+5. Relationship vs. Task Orientation  
 Some cultures value building a relationship before doing business. In Latin America or the Middle East, jumping straight into business may be perceived as rude. Be willing to invest time in rapport-building activities like shared meals or informal chats.
 
-**6. Interpreting Silence and Emotion**  
+6. Interpreting Silence and Emotion  
 Silence might indicate discomfort in one culture or deep consideration in another. Emotional expression may be welcome in Southern Europe, but avoided in Nordic countries. Emotional fluency helps you read the room accurately.
 
-**7. Building Trust Across Cultures**  
+7. Building Trust Across Cultures  
 Trust can be built through performance (task-based trust) or personal connection (relationship-based trust). Knowing which matters more to your counterpart allows you to act accordingly—either by showcasing competence or developing personal bonds.
 
-**Conclusion**  
+Conclusion  
 Cross-cultural negotiations are a blend of diplomacy, cultural awareness, and business acumen. With patience, research, and genuine curiosity, you can navigate differences and build bridges to global success.`
   },
   {
@@ -117,31 +117,31 @@ Cross-cultural negotiations are a blend of diplomacy, cultural awareness, and bu
     author: 'Alexandru Buruiana',
     image: 'https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg',
     excerpt: `Step-by-step guidance on negotiating job offers, raises, and benefits to maximize your compensation.`,
-    content: `**Introduction**  
+    content: `Introduction  
 Whether you're negotiating a new job offer or asking for a raise, your salary impacts not only your income but also your professional worth. Yet many professionals enter these conversations underprepared. This guide offers a structured approach to help you negotiate with confidence.
 
-**1. Do Your Homework**  
+1. Do Your Homework  
 Research industry benchmarks, company standards, and local market trends using tools like Glassdoor, Payscale, or LinkedIn Salary Insights. Understand what someone with your experience and skills typically earns.
 
-**2. Know Your Value**  
+2. Know Your Value  
 Beyond market data, assess your personal value: what unique skills, results, or qualifications do you bring? Keep a list of accomplishments, KPIs achieved, and testimonials to back your case.
 
-**3. Timing Matters**  
+3. Timing Matters  
 Initiate salary discussions at the right moment—usually after an offer has been made or during annual performance reviews. Avoid raising the topic during high-stress periods or company downturns.
 
-**4. Avoid Naming the First Number (If Possible)**  
+4. Avoid Naming the First Number (If Possible)  
 Let the employer make the first offer so you can evaluate your leverage. If pressed, give a range based on your research. Be realistic but aspirational.
 
-**5. Consider the Entire Package**  
+5. Consider the Entire Package  
 Salary is only one part of compensation. Think about benefits, bonuses, stock options, paid time off, flexibility, and professional development opportunities.
 
-**6. Practice Your Pitch**  
+6. Practice Your Pitch  
 Rehearse your negotiation script with a friend or coach. Focus on clarity, calmness, and confidence. Use phrases like “Based on my research and experience, I believe...” instead of “I need...” or “I want...”
 
-**7. Handle Objections Gracefully**  
+7. Handle Objections Gracefully  
 If your request is declined, ask for feedback and explore alternatives: earlier review cycles, performance-based bonuses, or extra vacation days.
 
-**Conclusion**  
+Conclusion  
 Salary negotiation is a skill you can—and should—develop. With preparation, timing, and a clear sense of your worth, you can shape a deal that reflects your true value.`
   },
   {
@@ -153,28 +153,28 @@ Salary negotiation is a skill you can—and should—develop. With preparation, 
     author: 'Alexandru Buruiana',
     image: 'https://images.pexels.com/photos/3182759/pexels-photo-3182759.jpeg',
     excerpt: `Learn how to expand the pie by creating value for both sides, forging long-term, collaborative relationships.`,
-    content: `**Introduction**  
+    content: `Introduction  
 Negotiation is often framed as a competition—but in many scenarios, collaboration yields greater rewards. Building win-win partnerships means going beyond splitting the pie and instead finding ways to make it bigger for everyone involved.
 
-**1. Shift from Positions to Interests**  
+1. Shift from Positions to Interests  
 Positional bargaining—“I want X” vs. “I want Y”—often leads to deadlock. Focus instead on the underlying interests. Why do both sides want what they want? Identifying shared interests opens the door to creative solutions.
 
-**2. Expand the Pie**  
+2. Expand the Pie  
 Before dividing value, look for ways to create more of it. Could you extend contract duration, offer additional services, or pool resources? Brainstorming together builds trust and uncovers opportunities that benefit both parties.
 
-**3. Joint Problem-Solving**  
+3. Joint Problem-Solving  
 Approach the negotiation as a collaborative puzzle rather than a contest. Use phrases like “How can we make this work for both of us?” instead of “Take it or leave it.” This mindset encourages open dialogue and transparency.
 
-**4. Build Long-Term Trust**  
+4. Build Long-Term Trust  
 Trust isn’t built overnight. Be consistent, deliver on your promises, and maintain integrity—even under pressure. Long-term partnerships are built on reliability, not just clever deal-making.
 
-**5. Use Contingency Agreements**  
+5. Use Contingency Agreements  
 If you and the other party disagree on future events or outcomes, use “if-then” clauses. For example: “If sales exceed X, then you receive a bonus.” These reduce risk and align incentives.
 
-**6. Balance Empathy with Assertiveness**  
+6. Balance Empathy with Assertiveness  
 Understand the other side’s challenges and pressures. At the same time, advocate for your needs clearly and confidently. This dual approach builds respect and reduces the chance of conflict.
 
-**Conclusion**  
+Conclusion  
 Win-win negotiations aren’t about being soft—they’re about being smart. By focusing on mutual gains, fostering trust, and solving problems together, you lay the foundation for sustainable success.`
   },
   {
@@ -186,34 +186,34 @@ Win-win negotiations aren’t about being soft—they’re about being smart. By
     author: 'Alexandru Buruiana',
     image: 'https://images.pexels.com/photos/3184436/pexels-photo-3184436.jpeg',
     excerpt: `Leverage market data and analytics to strengthen your position and secure better outcomes.`,
-    content: `**Introduction**  
+    content: `Introduction  
 In today's data-saturated world, information is power—especially in negotiation. While instincts and interpersonal skills remain essential, data-driven negotiators can quantify value, predict behavior, and justify demands more effectively. This article explores how to bring data into the heart of your strategy.
 
-**1. Know the Market Inside-Out**  
+1. Know the Market Inside-Out  
 Whether you're negotiating a salary, a merger, or a supplier contract, you must understand the relevant market dynamics. Analyze pricing benchmarks, competitor offerings, seasonal fluctuations, and economic indicators. Tools like industry reports, analytics dashboards, and even Google Trends can offer valuable insights.
 
-**2. Set Your Anchors with Evidence**  
+2. Set Your Anchors with Evidence  
 Opening offers backed by credible data carry more weight. For instance, instead of proposing a 10% discount arbitrarily, cite similar deals in the market or industry standards. This creates a rational basis for your position, making it harder to dismiss.
 
-**3. Use Historical Performance Data**  
+3. Use Historical Performance Data  
 Look at past negotiations or deals—what worked, what didn't, and why? By identifying patterns in behavior and outcomes, you can better prepare for what’s ahead. Use CRM data, internal reports, and meeting transcripts to sharpen your playbook.
 
-**4. Forecast Outcomes with Scenario Modeling**  
+4. Forecast Outcomes with Scenario Modeling  
 Use basic data modeling or tools like spreadsheets to simulate potential deal outcomes. What happens if delivery times shift? What if prices rise 5%? Being able to answer “what if” gives you greater leverage and foresight.
 
-**5. Monitor Concessions and Trade-Offs Quantitatively**  
+5. Monitor Concessions and Trade-Offs Quantitatively  
 Assign values to concessions (e.g., faster delivery = +$X, longer payment terms = -$Y). This helps you understand the real cost of each variable and prevents emotional decisions. Track them during the negotiation to avoid imbalance.
 
-**6. Visualize the Value**  
+6. Visualize the Value  
 Data can be persuasive when visualized well. Use charts or infographics to illustrate savings, growth, or ROI to stakeholders. This not only simplifies complex ideas but also gives your arguments visual impact.
 
-**7. Benchmark the Opponent (Ethically)**  
+7. Benchmark the Opponent (Ethically)  
 Leverage public databases, company filings, LinkedIn profiles, and social media to understand your counterpart’s position. Who are they negotiating with? What are their pressures and goals? Data offers clues to their pain points and priorities.
 
-**8. Measure and Improve**  
+8. Measure and Improve  
 After each negotiation, track key metrics: agreement rate, average concession value, negotiation length, satisfaction levels. Build a database over time to evaluate and optimize your overall negotiation effectiveness.
 
-**Conclusion**  
+Conclusion  
 Data doesn’t replace human intuition—it empowers it. By integrating analysis, evidence, and structured decision-making into your approach, you become a more credible, prepared, and persuasive negotiator.`
   },
 ];

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -16,14 +16,22 @@ const BlogPost: React.FC = () => {
       .trim()
       .split('\n\n')
       .map((p, i) => {
-        const heading = p.match(/^\*\*(.+)\*\*$/)
-        if (heading) {
+        if (/^(Introduction|Conclusion)$/i.test(p)) {
+          return (
+            <h2 key={i} className="text-2xl font-bold mt-6 mb-3">
+              {p}
+            </h2>
+          )
+        }
+
+        if (/^\d+\.\s/.test(p)) {
           return (
             <h3 key={i} className="text-lg font-semibold mt-4 mb-2">
-              {heading[1]}
+              {p}
             </h3>
           )
         }
+
         return (
           <p key={i} className="mb-2">
             {p}


### PR DESCRIPTION
## Summary
- remove manual asterisks in blog post data
- render h2 for Introduction and Conclusion
- render h3 for numbered sub-headings

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855723c5cf48333a99dcb9502421914