### PR TITLE
Aggiorna brand e contatti a DNego

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Nego Consulting Website</title>
+    <title>DNego Website</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -13,7 +13,7 @@ const Footer = () => {
           <div>
             <Link to="/" className="flex items-center gap-3 text-white font-bold text-2xl mb-4">
               <div className="flex items-center">
-                <span className="text-white font-serif">NEGO</span>
+                <span className="text-white font-serif">DNEGO</span>
                 <div className="w-2 h-2 bg-blue-400 rounded-full ml-2"></div>
               </div>
             </Link>
@@ -98,7 +98,7 @@ const Footer = () => {
             <ul className="space-y-4">
               <li className="flex items-start">
                 <Mail className="h-5 w-5 text-blue-400 mr-3 mt-0.5" />
-                <span className="text-gray-300">alexandru.buruiana@outlook.it</span>
+                <span className="text-gray-300">negotiation@dnego.com</span>
               </li>
               <li className="flex items-start">
                 <Phone className="h-5 w-5 text-blue-400 mr-3 mt-0.5" />
@@ -113,7 +113,7 @@ const Footer = () => {
         </div>
         
         <div className="border-t border-gray-800 py-6 text-center text-gray-400 text-sm">
-          <p>&copy; {currentYear} Nego Consulting. All rights reserved.</p>
+          <p>&copy; {currentYear} DNego. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -35,7 +35,7 @@ const Navbar: React.FC = () => {
           onClick={() => handleNavClick('/')}
           className="cursor-pointer text-2xl md:text-3xl font-serif font-bold text-navy-950"
         >
-          NEGO<span className="text-blue-700">●</span>
+          DNEGO<span className="text-blue-700">●</span>
         </span>
 
         {/* Menu desktop */}

--- a/src/components/sections/Blog.tsx
+++ b/src/components/sections/Blog.tsx
@@ -15,7 +15,7 @@ const BlogSection: React.FC = () => {
       <div className="container">
         <SectionHeading
           title="Blog & Academy"
-          subtitle="Stay informed with Nego's expert insights. Our blog offers practical articles and tips on negotiation and value creation."
+          subtitle="Stay informed with DNego's expert insights. Our blog offers practical articles and tips on negotiation and value creation."
         />
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -56,7 +56,7 @@ const Contact = () => {
                   <Mail className="h-6 w-6 text-blue-400 mr-4 mt-1" />
                   <div>
                     <h4 className="font-bold mb-1 text-white">Email</h4>
-                    <a href="mailto:alexandru.buruiana@outlook.it" className="text-gray-300 hover:text-blue-400 transition-colors">alexandru.buruiana@outlook.it</a>
+                    <a href="mailto:negotiation@dnego.com" className="text-gray-300 hover:text-blue-400 transition-colors">negotiation@dnego.com</a>
                   </div>
                 </div>
                 
@@ -81,7 +81,7 @@ const Contact = () => {
               <div className="mt-12">
                 <h4 className="text-xl font-bold mb-4 text-white">Upcoming Courses</h4>
                 <p className="text-gray-300 mb-4">
-                  Nego is developing online courses to train you in negotiation excellence. Enter your email in the form to receive updates and early access.
+                  DNego is developing online courses to train you in negotiation excellence. Enter your email in the form to receive updates and early access.
                 </p>
                 <ul className="list-disc list-inside text-gray-300">
                   <li>Advanced Negotiation Techniques</li>

--- a/src/components/sections/Founder.tsx
+++ b/src/components/sections/Founder.tsx
@@ -15,7 +15,7 @@ const Founder = () => {
             <div className="relative flex justify-center">
               <img
                 src="/Profile_Photo.jpg"
-                alt="Alexandru Buruiana, Founder of Nego"
+                alt="Alexandru Buruiana, Founder of DNego"
                 className="max-w-md w-full h-auto object-cover md:max-h-[20rem]" />
               <div className="absolute -bottom-6 -right-6 bg-blue-700 text-white py-2 px-4 rounded-lg shadow-md font-medium">
                 Alexandru Buruiana, Founder
@@ -33,7 +33,7 @@ const Founder = () => {
                 After a successful corporate tenure, he founded his own consulting practice to help clients secure better deals and meaningful savings. Alexandru applies his specialized knowledge to craft tailored strategies and blends analytical rigor with a personal touch to guide clients to success.
               </p>
               <p className="text-gray-600 mb-6">
-                Nego was born from the idea that expert negotiation skills should be available to everyone. Most people negotiate only a handful of high-value agreements in their lifetime, so mistakes can be costly. By leaving those negotiations to a professional—with no upfront cost—you safeguard your interests when it matters most.
+                DNego was born from the idea that expert negotiation skills should be available to everyone. Most people negotiate only a handful of high-value agreements in their lifetime, so mistakes can be costly. By leaving those negotiations to a professional—with no upfront cost—you safeguard your interests when it matters most.
               </p>
               <p className="text-gray-700 font-medium">
                 His commitment to integrity and client success means you always get straightforward advice and honest negotiations.

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -10,7 +10,7 @@ const About = () => {
         <div className="container">
           <div className="max-w-3xl mx-auto text-center">
             <ScrollAnimation animation="slide-up">
-              <h1 className="text-4xl md:text-5xl font-bold mb-6 text-white">About Nego</h1>
+              <h1 className="text-4xl md:text-5xl font-bold mb-6 text-white">About DNego</h1>
               <p className="text-xl text-gray-300 mb-6">
                 We are expert negotiators with a mission to help clients achieve better deals and significant savings with absolutely no risk.
               </p>
@@ -33,7 +33,7 @@ const About = () => {
             <ScrollAnimation animation="fade-in">
               <img 
                 src="https://images.pexels.com/photos/3183197/pexels-photo-3183197.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750"
-                alt="Nego team discussing strategy" 
+                alt="DNego team discussing strategy" 
                 className="rounded-lg shadow-xl"
               />
             </ScrollAnimation>
@@ -41,10 +41,10 @@ const About = () => {
             <ScrollAnimation animation="slide-up">
               <h2 className="text-3xl font-bold mb-6 text-navy-950">Our Story</h2>
               <p className="text-gray-600 mb-4">
-                Nego was founded in 2020 by Alexandru Buruiana after a decade of corporate procurement experience. Having witnessed countless negotiations where businesses overpaid due to lack of expertise or resources, Alexandru saw an opportunity to help.
+                DNego was founded in 2020 by Alexandru Buruiana after a decade of corporate procurement experience. Having witnessed countless negotiations where businesses overpaid due to lack of expertise or resources, Alexandru saw an opportunity to help.
               </p>
               <p className="text-gray-600 mb-4">
-                What began as a solo consulting practice quickly grew as clients experienced the power of professional negotiation. Today, Nego works with organizations across industries, delivering measurable savings with our unique performance-based model.
+                What began as a solo consulting practice quickly grew as clients experienced the power of professional negotiation. Today, DNego works with organizations across industries, delivering measurable savings with our unique performance-based model.
               </p>
               <p className="text-gray-700 font-medium">
                 We've helped clients save millions through better negotiation, earning our fee only from actual results. Our growing team combines corporate experience with specialized industry knowledge to deliver exceptional outcomes.

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -68,7 +68,7 @@ const Contact = () => {
                     <Mail className="h-6 w-6 text-blue-400 mr-4 mt-1" />
                     <div>
                       <h4 className="font-bold mb-1 text-white">Email</h4>
-                      <a href="mailto:alexandru.buruiana@outlook.it" className="text-gray-300 hover:text-blue-400 transition-colors">alexandru.buruiana@outlook.it</a>
+                      <a href="mailto:negotiation@dnego.com" className="text-gray-300 hover:text-blue-400 transition-colors">negotiation@dnego.com</a>
                     </div>
                   </div>
                   

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -27,7 +27,7 @@ const Privacy = () => {
             <article className="prose lg:prose-lg text-gray-700">
               <h2>1. Introduction</h2>
               <p>
-                Nego Consulting collects and processes personal data in
+                DNego collects and processes personal data in
                 accordance with this Privacy Policy and applicable laws. By
                 using our website or services, you consent to this processing.
               </p>
@@ -77,7 +77,7 @@ const Privacy = () => {
               <h2>8. Contact Us</h2>
               <p>
                 For questions about this Privacy Policy, please email
-                alexandru.buruiana@outlook.it.
+                negotiation@dnego.com.
               </p>
             </article>
           </ScrollAnimation>

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -26,7 +26,7 @@ const Terms = () => {
             <article className="prose lg:prose-lg text-gray-700">
               <h2>1. Acceptance of Terms</h2>
               <p>
-                By accessing or using Nego Consulting&apos;s website or services, you
+                By accessing or using DNego&apos;s website or services, you
                 agree to be bound by these Terms of Service. If you do not agree
                 with any part of the terms, you should not use our site or
                 engage our services.
@@ -34,7 +34,7 @@ const Terms = () => {
 
               <h2>2. Services Provided</h2>
               <p>
-                Nego Consulting offers professional negotiation and consulting
+                DNego offers professional negotiation and consulting
                 services. Specific deliverables and timelines will be outlined in
                 our written agreement or proposal.
               </p>
@@ -56,14 +56,14 @@ const Terms = () => {
               <h2>5. Intellectual Property</h2>
               <p>
                 All content on this site, including text, images, and graphics,
-                is the property of Nego Consulting. You may not reproduce or
+                is the property of DNego. You may not reproduce or
                 distribute any materials without prior written consent.
               </p>
 
               <h2>6. Limitation of Liability</h2>
               <p>
                 We strive to provide accurate advice, but we cannot guarantee any
-                specific outcome. To the fullest extent permitted by law, Nego
+                specific outcome. To the fullest extent permitted by law, DNego
                 Consulting shall not be liable for indirect or consequential
                 damages arising from the use of our services or website.
               </p>
@@ -84,7 +84,7 @@ const Terms = () => {
               <h2>9. Contact Us</h2>
               <p>
                 For questions about these Terms of Service, please email us at
-                alexandru.buruiana@outlook.it.
+                negotiation@dnego.com.
               </p>
             </article>
           </ScrollAnimation>


### PR DESCRIPTION
## Summary
- aggiorna il titolo principale in `index.html`
- sostituisce il marchio NEGO con DNEGO in navbar e footer
- aggiorna il testo delle sezioni per usare DNego invece di Nego
- aggiorna l'indirizzo email a `negotiation@dnego.com`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab241871083339a34fc9bed28070c