### PR TITLE
Remove 'com' from DNego brand

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -114,7 +114,7 @@ const Footer = () => {
         </div>
         
         <div className="border-t border-gray-800 py-6 text-center text-gray-400 text-sm">
-          <p>&copy; {currentYear} DNego<span className="text-blue-400 mx-1">●</span>com. All rights reserved.</p>
+          <p>&copy; {currentYear} DNego<span className="text-blue-400 mx-1">●</span>. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -35,7 +35,7 @@ const Navbar: React.FC = () => {
           onClick={() => handleNavClick('/')}
           className="cursor-pointer text-2xl md:text-3xl font-serif font-bold text-navy-950"
         >
-          DNego<span className="text-blue-700">●</span>com
+          DNego<span className="text-blue-700">●</span>
         </span>
 
         {/* Menu desktop */}


### PR DESCRIPTION
## Summary
- remove trailing `com` from brand name in Navbar
- remove trailing `com` from brand name in Footer

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ab6be73f48333b516546168b60abf