### PR TITLE
Adjust hero gradient

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -13,7 +13,7 @@ const Hero: React.FC = () => {
         className="absolute inset-0"
         style={{
           background:
-            'linear-gradient(to right, rgba(255,255,255,0.85) 0%, rgba(255,255,255,0.5) 40%, rgba(255,255,255,0) 100%)',
+            'linear-gradient(to right, rgba(255,255,255,0.85) 0%, rgba(255,255,255,0.6) 25%, rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.05) 75%, rgba(255,255,255,0) 100%)',
         }}
       />
 


### PR DESCRIPTION
## Summary
- make the hero overlay fade out faster towards the right

## Testing
- `npm run lint` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ad2187e40833389f445e01e2aa63f