### PR TITLE
Add logging and catch around EmailJS

### DIFF
--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -28,12 +28,22 @@ const Contact = () => {
 
     try {
       if (formRef.current) {
-        await emailjs.sendForm(
+        console.log(
           import.meta.env.VITE_EMAILJS_SERVICE_ID,
           import.meta.env.VITE_EMAILJS_TEMPLATE_ID,
-          formRef.current,
-          import.meta.env.VITE_EMAILJS_PUBLIC_KEY
+          import.meta.env.VITE_EMAILJS_PUBLIC_KEY,
+          formRef.current
         );
+        try {
+          await emailjs.sendForm(
+            import.meta.env.VITE_EMAILJS_SERVICE_ID,
+            import.meta.env.VITE_EMAILJS_TEMPLATE_ID,
+            formRef.current,
+            import.meta.env.VITE_EMAILJS_PUBLIC_KEY
+          );
+        } catch (error) {
+          console.error(error);
+        }
       }
 
       setSubmitted(true);

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -29,12 +29,22 @@ const Contact = () => {
 
     try {
       if (formRef.current) {
-        await emailjs.sendForm(
+        console.log(
           import.meta.env.VITE_EMAILJS_SERVICE_ID,
           import.meta.env.VITE_EMAILJS_TEMPLATE_ID,
-          formRef.current,
-          import.meta.env.VITE_EMAILJS_PUBLIC_KEY
+          import.meta.env.VITE_EMAILJS_PUBLIC_KEY,
+          formRef.current
         );
+        try {
+          await emailjs.sendForm(
+            import.meta.env.VITE_EMAILJS_SERVICE_ID,
+            import.meta.env.VITE_EMAILJS_TEMPLATE_ID,
+            formRef.current,
+            import.meta.env.VITE_EMAILJS_PUBLIC_KEY
+          );
+        } catch (error) {
+          console.error(error);
+        }
       }
 
       setSubmitted(true);


### PR DESCRIPTION
## Summary
- add console.log of env vars and form ref before sending form
- wrap `emailjs.sendForm` in its own try/catch with `console.error`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68629e1c9a20833389297eabcfd51682