### PR TITLE
Add confirmation comments for phone field

### DIFF
--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -166,6 +166,7 @@ const Contact = () => {
                   <label htmlFor="phone" className="block text-gray-700 font-medium mb-2">
                     Phone Number (optional)
                   </label>
+                  {/* Verified: this input is within the formRef and will be sent via emailjs.sendForm */}
                   <input
                     type="tel"
                     id="phone"

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -178,6 +178,7 @@ const Contact = () => {
                       <label htmlFor="phone" className="block text-gray-700 font-medium mb-2">
                         Phone Number
                       </label>
+                      {/* Verified: this input is within the formRef and will be sent via emailjs.sendForm */}
                       <input
                         type="tel"
                         id="phone"


### PR DESCRIPTION
## Summary
- clarify that the phone input is included in forms sent with `emailjs.sendForm`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68638706a2c083339c4f5de159958e3d