### PR TITLE
Remove company field and confirm phone support

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -10,7 +10,6 @@ const Contact = () => {
     user_name: '',
     user_email: '',
     user_phone: '',
-    company: '',
     user_message: '',
   });
 
@@ -53,7 +52,6 @@ const Contact = () => {
         user_name: '',
         user_email: '',
         user_phone: '',
-        company: '',
         user_message: '',
       });
 
@@ -191,20 +189,6 @@ const Contact = () => {
                       />
                     </div>
                     
-                    <div>
-                      <label htmlFor="company" className="block text-gray-700 font-medium mb-2">
-                        Company/Organization
-                      </label>
-                      <input
-                        type="text"
-                        id="company"
-                        name="company"
-                        value={formData.company}
-                        onChange={handleChange}
-                        className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-700 focus:border-blue-700 text-gray-900"
-                        placeholder="Your company"
-                      />
-                    </div>
                   </div>
                   
                   <div className="mb-6">


### PR DESCRIPTION
## Summary
- remove `company` field from Contact page state, reset and JSX
- keep Free Consultation button linking to Contact page
- confirm phone number input is included on both contact forms

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863935149b48333a40862d9db6d48ef