### PR TITLE
Update privacy consent links

### DIFF
--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -208,6 +208,25 @@ const Contact = () => {
                   />
                 </div>
 
+                <div className="flex items-center mb-8">
+                  <input
+                    type="checkbox"
+                    id="privacy"
+                    className="h-4 w-4 text-blue-700 border-gray-300 rounded focus:ring-blue-700"
+                    required
+                  />
+                  <label
+                    htmlFor="privacy"
+                    className="ml-2 block text-sm text-gray-700"
+                  >
+                    I agree to the{" "}
+                    <a href="/privacy" className="text-blue-700 underline">
+                      privacy policy
+                    </a>{" "}
+                    and consent to being contacted regarding my inquiry.
+                  </label>
+                </div>
+
                 <Button
                   variant="primary"
                   size="lg"

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -234,7 +234,7 @@ const Contact = () => {
                       className="ml-2 block text-sm text-gray-700"
                     >
                       I agree to the{" "}
-                      <a href="#" className="text-blue-700 underline">
+                      <a href="/privacy" className="text-blue-700 underline">
                         privacy policy
                       </a>{" "}
                       and consent to being contacted regarding my inquiry.


### PR DESCRIPTION
## Summary
- update contact form privacy policy link to /privacy route
- add privacy consent checkbox and link to home page contact form

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68665a8f9e7083339269063d347c599a