### PR TITLE
Add bilingual language switcher

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,7 +1,9 @@
 import { Link } from 'react-router-dom';
 import { Facebook, Twitter, Linkedin, Instagram, Mail, Phone, MapPin } from 'lucide-react';
+import { useLanguage } from '../../contexts/LanguageContext';
 
 const Footer = () => {
+  const { t } = useLanguage();
   const currentYear = new Date().getFullYear();
   
   return (
@@ -19,7 +21,7 @@ const Footer = () => {
               </div>
             </Link>
             <p className="text-gray-300 mb-6">
-              Expert negotiation services with a no-risk, performance-based model. We only succeed when you save money.
+              {t('footer.companyInfo', 'Expert negotiation services with a no-risk, performance-based model. We only succeed when you save money.')}
             </p>
             <div className="flex space-x-4">
               <a href="#" aria-label="Facebook" className="text-gray-300 hover:text-blue-400 transition-colors">
@@ -39,7 +41,7 @@ const Footer = () => {
           
           {/* Quick Links */}
           <div>
-            <h3 className="text-lg font-bold mb-4 text-white">Quick Links</h3>
+            <h3 className="text-lg font-bold mb-4 text-white">{t('footer.quickLinks', 'Quick Links')}</h3>
             <ul className="space-y-3">
               {[
                 { name: 'Home', path: '/' },
@@ -55,7 +57,7 @@ const Footer = () => {
                     to={item.path}
                     className="text-gray-300 hover:text-blue-400 transition-colors"
                   >
-                    {item.name}
+                {t(`nav.${item.name.toLowerCase().replace(/\s/g,'')}`, item.name)}
                   </Link>
                 </li>
               ))}
@@ -64,14 +66,14 @@ const Footer = () => {
           
           {/* Our Services */}
           <div>
-            <h3 className="text-lg font-bold mb-4 text-white">Our Services</h3>
+            <h3 className="text-lg font-bold mb-4 text-white">{t('footer.ourServices', 'Our Services')}</h3>
             <ul className="space-y-3">
               <li>
                 <a
                   href="/services#real-estate"
                   className="text-gray-300 hover:text-blue-400 transition-colors"
                 >
-                  Real Estate Negotiation
+                  {t('servicesPreview.realEstate.title', 'Real Estate Negotiation')}
                 </a>
               </li>
               <li>
@@ -79,7 +81,7 @@ const Footer = () => {
                   href="/services#salary-benefits"
                   className="text-gray-300 hover:text-blue-400 transition-colors"
                 >
-                  Salary & Benefits Negotiation
+                  {t('servicesPreview.salary.title', 'Salary & Benefits Negotiation')}
                 </a>
               </li>
               <li>
@@ -87,7 +89,7 @@ const Footer = () => {
                   href="/services#consultation"
                   className="text-gray-300 hover:text-blue-400 transition-colors"
                 >
-                  Business Consultation Services
+                  {t('servicesPreview.consulting.title', 'Business Consultation Services')}
                 </a>
               </li>
             </ul>
@@ -95,7 +97,7 @@ const Footer = () => {
           
           {/* Contact Info */}
           <div>
-            <h3 className="text-lg font-bold mb-4 text-white">Contact Us</h3>
+            <h3 className="text-lg font-bold mb-4 text-white">{t('footer.contactUs', 'Contact Us')}</h3>
             <ul className="space-y-4">
               <li className="flex items-start">
                 <Mail className="h-5 w-5 text-blue-400 mr-3 mt-0.5" />
@@ -114,7 +116,7 @@ const Footer = () => {
         </div>
         
         <div className="border-t border-gray-800 py-6 text-center text-gray-400 text-sm">
-          <p>&copy; {currentYear} DNego<span className="text-blue-400 mx-1">●</span>. All rights reserved.</p>
+          <p>&copy; {currentYear} DNego<span className="text-blue-400 mx-1">●</span>. {t('footer.rights', 'All rights reserved.')}</p>
         </div>
       </div>
     </footer>

--- a/src/components/layout/LanguageSwitcher.tsx
+++ b/src/components/layout/LanguageSwitcher.tsx
@@ -1,0 +1,29 @@
+import { useLanguage } from '../../contexts/LanguageContext';
+
+const LanguageSwitcher = () => {
+  const { language, setLanguage } = useLanguage();
+
+  const optionClass = (lang: string) =>
+    `cursor-pointer flex items-center space-x-1 px-2 ${language === lang ? 'font-bold underline' : ''}`;
+
+  return (
+    <div className="flex space-x-2 text-sm">
+      <span
+        className={optionClass('it')}
+        onClick={() => setLanguage('it')}
+      >
+        <span>🇮🇹</span>
+        <span>IT</span>
+      </span>
+      <span
+        className={optionClass('en')}
+        onClick={() => setLanguage('en')}
+      >
+        <span>🇬🇧</span>
+        <span>EN</span>
+      </span>
+    </div>
+  );
+};
+
+export default LanguageSwitcher;

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
+import LanguageSwitcher from './LanguageSwitcher';
+import { useLanguage } from '../../contexts/LanguageContext';
 
 const Navbar: React.FC = () => {
   const [scrolled, setScrolled] = useState(false);
   const location = useLocation();
   const navigate = useNavigate();
+  const { t } = useLanguage();
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 20);
@@ -40,11 +43,11 @@ const Navbar: React.FC = () => {
 
         {/* Menu desktop */}
         <nav className="hidden md:flex space-x-6">
-          {['Home', 'About', 'Services', 'Blog', 'Contact'].map((name) => {
-            const path = name === 'Home' ? '/' : `/${name.toLowerCase()}`;
+          {['home', 'about', 'services', 'blog', 'contact'].map((key) => {
+            const path = key === 'home' ? '/' : `/${key}`;
             return (
               <NavLink
-                key={name}
+                key={key}
                 to={path}
                 onClick={(e) => {
                   e.preventDefault(); // evita navigazione doppia
@@ -58,15 +61,16 @@ const Navbar: React.FC = () => {
                   }`
                 }
               >
-                {name}
+                {t(`nav.${key}`, key)}
               </NavLink>
             );
           })}
         </nav>
 
-        {/* Mobile menu toggle */}
-        <div className="md:hidden">
-          {/* ...burger menu... */}
+        <div className="flex items-center space-x-4">
+          <LanguageSwitcher />
+          {/* Mobile menu toggle */}
+          <div className="md:hidden">{/* ...burger menu... */}</div>
         </div>
       </div>
     </header>

--- a/src/components/sections/Founder.tsx
+++ b/src/components/sections/Founder.tsx
@@ -1,12 +1,14 @@
 import SectionHeading from '../ui/SectionHeading';
 import ScrollAnimation from '../utils/ScrollAnimation';
+import { useLanguage } from '../../contexts/LanguageContext';
 
 const Founder = () => {
+  const { t } = useLanguage();
   return (
     <section className="section bg-white">
       <div className="container">
         <SectionHeading
-          title="About the Founder"
+          title={t('founder.about', 'About the Founder')}
           centered={false}
         />
 

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,8 +1,10 @@
 import { ArrowRight } from 'lucide-react';
 import Button from '../ui/Button';
 import ScrollAnimation from '../utils/ScrollAnimation';
+import { useLanguage } from '../../contexts/LanguageContext';
 
 const Hero: React.FC = () => {
+  const { t } = useLanguage();
   return (
     <section
       className="relative bg-cover bg-center bg-no-repeat h-screen flex items-center"
@@ -22,7 +24,7 @@ const Hero: React.FC = () => {
         <div className="max-w-lg">
           <ScrollAnimation animation="fade-in">
             <h1 className="text-2xl md:text-3xl lg:text-4xl font-semibold text-navy-950 mb-4">
-              The art of negotiation at your service, for a fair deal
+              {t('hero.title', 'The art of negotiation at your service, for a fair deal')}
             </h1>
           </ScrollAnimation>
 
@@ -32,7 +34,7 @@ const Hero: React.FC = () => {
 
           <ScrollAnimation animation="slide-up" delay={300}>
             <p className="text-sm md:text-base text-gray-700 mb-8">
-              Trust our expertise&nbsp;—&nbsp;our compensation is solely a share of the savings we deliver.
+              {t('hero.subtitle', 'Trust our expertise — our compensation is solely a share of the savings we deliver.')}
             </p>
           </ScrollAnimation>
 
@@ -46,7 +48,7 @@ const Hero: React.FC = () => {
                 iconPosition="right"
                 className="bg-navy-950 hover:bg-navy-900"
               >
-                Free Consultation
+                {t('hero.cta', 'Free Consultation')}
               </Button>
               <Button
                 variant="outline"
@@ -54,7 +56,7 @@ const Hero: React.FC = () => {
                 href="/services"
                 className="border-navy-950 text-navy-950 hover:bg-navy-950 hover:text-white"
               >
-                View Services
+                {t('hero.secondary', 'View Services')}
               </Button>
             </div>
           </ScrollAnimation>
@@ -68,7 +70,7 @@ const Hero: React.FC = () => {
           href="#why-choose-us"
           className="flex flex-col items-center text-navy-950 hover:opacity-80 transition-opacity"
         >
-          <span className="text-sm mb-1">Scroll</span>
+          <span className="text-sm mb-1">{t('hero.scroll', 'Scroll')}</span>
           <svg
             className="w-6 h-6"
             fill="none"

--- a/src/components/sections/HowItWorks.tsx
+++ b/src/components/sections/HowItWorks.tsx
@@ -1,6 +1,7 @@
 import { MessageCircle, PieChart, Users, CheckCircle } from 'lucide-react';
 import SectionHeading from '../ui/SectionHeading';
 import ScrollAnimation from '../utils/ScrollAnimation';
+import { useLanguage } from '../../contexts/LanguageContext';
 
 const steps = [
   {
@@ -26,12 +27,13 @@ const steps = [
 ];
 
 const HowItWorks = () => {
+  const { t } = useLanguage();
   return (
     <section className="section bg-white">
       <div className="container">
         <SectionHeading
-          title="How It Works"
-          subtitle="Our proven four-step process delivers measurable results with no upfront costs"
+          title={t('how.title', 'How It Works')}
+          subtitle={t('how.subtitle', 'Our proven four-step process delivers measurable results with no upfront costs')}
         />
         
         <div className="relative">
@@ -62,9 +64,9 @@ const HowItWorks = () => {
                     <div className="bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300 border">
                       <div className={`flex items-center mb-4 md:${index % 2 === 0 ? 'justify-end' : ''}`}>
                         <step.icon className={`h-8 w-8 text-blue-700 ${index % 2 === 0 ? 'md:order-2 md:ml-4' : 'mr-4'}`} />
-                        <h3 className="text-xl font-bold text-navy-950">{step.title}</h3>
+                        <h3 className="text-xl font-bold text-navy-950">{t(`how.step${index+1}.title`, step.title)}</h3>
                       </div>
-                      <p className="text-gray-600">{step.description}</p>
+                      <p className="text-gray-600">{t(`how.step${index+1}.desc`, step.description)}</p>
                     </div>
                   </div>
                 </div>

--- a/src/components/sections/ServicesPreview.tsx
+++ b/src/components/sections/ServicesPreview.tsx
@@ -2,19 +2,23 @@ import { Home, DollarSign, Handshake, ArrowRight } from 'lucide-react';
 import SectionHeading from '../ui/SectionHeading';
 import ScrollAnimation from '../utils/ScrollAnimation';
 import Button from '../ui/Button';
+import { useLanguage } from '../../contexts/LanguageContext';
 
 const services = [
   {
+    key: "realEstate",
     icon: Home,
     title: 'Real Estate Negotiation',
     description: 'Expert support for property purchases, mortgage optimization, and rental agreements to secure the best terms and pricing.',
   },
   {
+    key: "salary",
     icon: DollarSign,
     title: 'Salary & Benefits Negotiation',
     description: 'Maximize your earning potential through strategic compensation negotiations and comprehensive benefits package optimization.',
   },
   {
+    key: "consulting",
     icon: Handshake,
     title: 'Business Consultation Services',
     description: 'Strategic negotiation consulting and training to enhance your business deals and commercial agreements.',
@@ -22,12 +26,13 @@ const services = [
 ];
 
 const ServicesPreview = () => {
+  const { t } = useLanguage();
   return (
     <section className="section bg-gray-50">
       <div className="container">
         <SectionHeading
-          title="Our Core Services"
-          subtitle="Specialized negotiation expertise where you need it most"
+          title={t('servicesPreview.title', 'Our Core Services')}
+          subtitle={t('servicesPreview.subtitle', 'Specialized negotiation expertise where you need it most')}
         />
         
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
@@ -42,8 +47,8 @@ const ServicesPreview = () => {
                 <div className="flex items-center justify-center w-16 h-16 bg-blue-100 text-blue-700 rounded-full mb-6 group-hover:bg-blue-700 group-hover:text-white transition-colors duration-300">
                   <service.icon className="h-8 w-8" />
                 </div>
-                <h3 className="text-xl font-bold mb-4 text-navy-950">{service.title}</h3>
-                <p className="text-gray-600 mb-6 flex-grow">{service.description}</p>
+                <h3 className="text-xl font-bold mb-4 text-navy-950">{t(`servicesPreview.${service.key}.title`, service.title)}</h3>
+                <p className="text-gray-600 mb-6 flex-grow">{t(`servicesPreview.${service.key}.desc`, service.description)}</p>
                 <Button 
                   variant="outline" 
                   href="/services"
@@ -52,7 +57,7 @@ const ServicesPreview = () => {
                   iconPosition="right"
                   className="w-full"
                 >
-                  Learn More
+                  {t('servicesPreview.more', 'Learn More')}
                 </Button>
               </div>
             </ScrollAnimation>
@@ -62,14 +67,14 @@ const ServicesPreview = () => {
         <div className="mt-12 text-center">
           <ScrollAnimation animation="fade-in" delay={400}>
             <p className="text-gray-600 mb-6">
-              Ready to start saving? We only get paid when you save money.
+              {t('servicesPreview.ready', 'Ready to start saving? We only get paid when you save money.')}
             </p>
-            <Button 
-              variant="primary" 
+            <Button
+              variant="primary"
               size="lg"
               href="/contact"
             >
-              Schedule Your Free Consultation
+              {t('servicesPreview.contact', 'Schedule Your Free Consultation')}
             </Button>
           </ScrollAnimation>
         </div>

--- a/src/components/sections/WhyChooseUs.tsx
+++ b/src/components/sections/WhyChooseUs.tsx
@@ -1,6 +1,7 @@
 import { CreditCard, Shield, Target } from 'lucide-react';
 import SectionHeading from '../ui/SectionHeading';
 import ScrollAnimation from '../utils/ScrollAnimation';
+import { useLanguage } from '../../contexts/LanguageContext';
 
 const features = [
   {
@@ -21,12 +22,13 @@ const features = [
 ];
 
 const WhyChooseUs = () => {
+  const { t } = useLanguage();
   return (
     <section id="why-choose-us" className="section bg-gray-50">
       <div className="container">
         <SectionHeading
-          title="Why Choose Us"
-          subtitle="We combine expertise, transparency and a risk-free approach to deliver exceptional value"
+          title={t('choose.title', 'Why Choose Us')}
+          subtitle={t('choose.subtitle', 'We combine expertise, transparency and a risk-free approach to deliver exceptional value')}
         />
         
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
@@ -39,8 +41,8 @@ const WhyChooseUs = () => {
             >
               <div className="bg-white rounded-lg shadow-md p-8 h-full border-t-4 border-blue-700 hover:shadow-lg transition-shadow duration-300">
                 <feature.icon className="h-12 w-12 text-blue-700 mb-6" />
-                <h3 className="text-xl font-bold mb-3 text-navy-950">{feature.title}</h3>
-                <p className="text-gray-600">{feature.description}</p>
+                <h3 className="text-xl font-bold mb-3 text-navy-950">{t(`choose.feature${index+1}.title`, feature.title)}</h3>
+                <p className="text-gray-600">{t(`choose.feature${index+1}.desc`, feature.description)}</p>
               </div>
             </ScrollAnimation>
           ))}

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import it from '../i18n/it';
+
+export type Language = 'en' | 'it';
+
+interface LanguageContextProps {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+  t: (key: string, defaultText: string) => string;
+}
+
+const ItalianTranslations: Record<string, string> = it;
+
+const LanguageContext = createContext<LanguageContextProps | undefined>(undefined);
+
+export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [language, setLanguage] = useState<Language>(() => {
+    return (localStorage.getItem('lang') as Language) || 'en';
+  });
+
+  useEffect(() => {
+    localStorage.setItem('lang', language);
+  }, [language]);
+
+  const t = (key: string, defaultText: string) => {
+    if (language === 'it') {
+      return ItalianTranslations[key] || defaultText;
+    }
+    return defaultText;
+  };
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => {
+  const ctx = useContext(LanguageContext);
+  if (!ctx) throw new Error('useLanguage must be used within LanguageProvider');
+  return ctx;
+};

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -1,0 +1,68 @@
+const it = {
+  // Navbar
+  'nav.home': 'Home',
+  'nav.about': 'Chi siamo',
+  'nav.services': 'Servizi',
+  'nav.blog': 'Blog',
+  'nav.contact': 'Contatti',
+  'nav.termsofservice': 'Termini di Servizio',
+  'nav.privacypolicy': 'Privacy',
+
+  // Footer
+  'footer.quickLinks': 'Link Rapidi',
+  'footer.ourServices': 'I Nostri Servizi',
+  'footer.contactUs': 'Contattaci',
+  'footer.terms': 'Termini di Servizio',
+  'footer.privacy': 'Privacy',
+  'footer.companyInfo': 'Servizi di negoziazione esperti con un modello senza rischi. Guadagniamo solo quando risparmi.',
+  'footer.rights': 'Tutti i diritti riservati.',
+
+  // Hero
+  'hero.title': 'L\'arte della negoziazione al tuo servizio, per un accordo equo',
+  'hero.subtitle': 'Affidati alla nostra esperienza — siamo pagati solo con una percentuale dei risparmi ottenuti.',
+  'hero.cta': 'Consulenza Gratuita',
+  'hero.secondary': 'Scopri i Servizi',
+  'hero.scroll': 'Scorri',
+
+  // Services Preview
+  'servicesPreview.title': 'I Nostri Servizi Principali',
+  'servicesPreview.subtitle': 'Competenza specializzata nelle negoziazioni dove serve di più',
+  'servicesPreview.realEstate.title': 'Negoziazione Immobiliare',
+  'servicesPreview.realEstate.desc': 'Supporto esperto per acquisti, ottimizzazione mutui e affitti ai migliori termini.',
+  'servicesPreview.salary.title': 'Negoziazione Stipendio e Benefici',
+  'servicesPreview.salary.desc': 'Massimizza il potenziale di guadagno con trattative strategiche e ottimizzazione dei benefit.',
+  'servicesPreview.consulting.title': 'Consulenza Aziendale',
+  'servicesPreview.consulting.desc': 'Consulenza e formazione strategica per migliorare accordi commerciali.',
+  'servicesPreview.more': 'Scopri di più',
+  'servicesPreview.ready': 'Pronto a iniziare a risparmiare? Siamo pagati solo quando risparmi.',
+  'servicesPreview.contact': 'Prenota la tua consulenza gratuita',
+
+  // Why Choose Us
+  'choose.title': 'Perché Sceglierci',
+  'choose.subtitle': 'Uniamo competenza, trasparenza e un approccio senza rischi per offrirti valore eccezionale',
+  'choose.feature1.title': 'Modello 100% senza rischi',
+  'choose.feature1.desc': 'Riusciamo solo quando riesci tu. Paghi solo se riduciamo i costi (guadagniamo il 50% dei risparmi).',
+  'choose.feature2.title': 'Fiducia e Trasparenza',
+  'choose.feature2.desc': 'Costruiamo fiducia con processi chiari ed etici. Saprai sempre come e perché prendiamo le decisioni.',
+  'choose.feature3.title': 'Strategie Personalizzate',
+  'choose.feature3.desc': 'Ogni negoziazione è unica. Progettiamo piani su misura basati sui tuoi obiettivi e su metodologie collaudate.',
+
+  // How It Works
+  'how.title': 'Come Funziona',
+  'how.subtitle': 'Il nostro processo in quattro step garantisce risultati misurabili senza costi iniziali',
+  'how.step1.title': 'Consulenza Gratuita',
+  'how.step1.desc': 'Discutiamo delle tue esigenze e analizziamo i contratti senza alcun costo.',
+  'how.step2.title': 'Analisi e Strategia',
+  'how.step2.desc': 'Verifichiamo accordi e mercato per sviluppare un piano di negoziazione.',
+  'how.step3.title': 'Negoziazione Esperta',
+  'how.step3.desc': 'I nostri negoziatori conducono le trattative seguendo una strategia basata sui dati.',
+  'how.step4.title': 'Risultati e Pagamento',
+  'how.step4.desc': 'Concludiamo l\'accordo migliorato e condividiamo i risparmi al 50%.',
+
+  // Founder
+  'founder.section': 'Il Fondatore',
+  'founder.about': 'Riguardo al Fondatore',
+  'founder.bio1': 'Alexandru Buruiana vanta oltre cinque anni di esperienza internazionale nella negoziazione...',
+};
+
+export default it;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,15 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
+import { LanguageProvider } from './contexts/LanguageContext';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <LanguageProvider>
+        <App />
+      </LanguageProvider>
     </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add LanguageProvider with translation helper
- create Italian translations
- add LanguageSwitcher component visible in Navbar
- localize hero, footer, and some sections
- save language in localStorage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68667912ec3c83339e62034e741f1680