### PR TITLE
Improve navbar alignment and language dropdown

### DIFF
--- a/src/components/layout/LanguageSwitcher.tsx
+++ b/src/components/layout/LanguageSwitcher.tsx
@@ -1,27 +1,46 @@
+import { useState, useRef, useEffect } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { useLanguage } from '../../contexts/LanguageContext';
 
 const LanguageSwitcher = () => {
   const { language, setLanguage } = useLanguage();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('click', handler);
+    return () => document.removeEventListener('click', handler);
+  }, []);
 
   const optionClass = (lang: string) =>
-    `cursor-pointer flex items-center space-x-1 px-2 ${language === lang ? 'font-bold underline' : ''}`;
+    `cursor-pointer flex items-center space-x-2 px-3 py-1 ${
+      language === lang ? 'font-bold bg-gray-100' : ''
+    }`;
 
   return (
-    <div className="flex space-x-2 text-sm">
-      <span
-        className={optionClass('it')}
-        onClick={() => setLanguage('it')}
+    <div className="relative" ref={ref}>
+      <button
+        className="flex items-center space-x-1 text-sm border px-2 py-1 rounded hover:bg-gray-100"
+        onClick={() => setOpen((o) => !o)}
       >
-        <span>🇮🇹</span>
-        <span>IT</span>
-      </span>
-      <span
-        className={optionClass('en')}
-        onClick={() => setLanguage('en')}
-      >
-        <span>🇬🇧</span>
-        <span>EN</span>
-      </span>
+        <span>{language === 'it' ? '🇮🇹 IT' : '🇬🇧 EN'}</span>
+        <ChevronDown className="w-4 h-4" />
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-1 bg-white border rounded shadow-lg text-sm">
+          <div className={optionClass('it')} onClick={() => setLanguage('it')}>
+            <span>🇮🇹</span>
+            <span>IT</span>
+          </div>
+          <div className={optionClass('en')} onClick={() => setLanguage('en')}>
+            <span>🇬🇧</span>
+            <span>EN</span>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -41,36 +41,39 @@ const Navbar: React.FC = () => {
           DNego<span className="text-blue-700">●</span>
         </span>
 
-        {/* Menu desktop */}
-        <nav className="hidden md:flex space-x-6">
-          {['home', 'about', 'services', 'blog', 'contact'].map((key) => {
-            const path = key === 'home' ? '/' : `/${key}`;
-            return (
-              <NavLink
-                key={key}
-                to={path}
-                onClick={(e) => {
-                  e.preventDefault(); // evita navigazione doppia
-                  handleNavClick(path);
-                }}
-                className={({ isActive }) =>
-                  `cursor-pointer text-base md:text-lg font-medium transition-colors ${
-                    isActive
-                      ? 'text-blue-700'
-                      : 'text-navy-950 hover:text-blue-700'
-                  }`
-                }
-              >
-                {t(`nav.${key}`, key)}
-              </NavLink>
-            );
-          })}
-        </nav>
-
-        <div className="flex items-center space-x-4">
+        {/* Right side: links and language */}
+        <div className="hidden md:flex items-center space-x-6">
+          <nav className="flex space-x-6">
+            {['home', 'about', 'services', 'blog', 'contact'].map((key) => {
+              const path = key === 'home' ? '/' : `/${key}`;
+              return (
+                <NavLink
+                  key={key}
+                  to={path}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handleNavClick(path);
+                  }}
+                  className={({ isActive }) =>
+                    `cursor-pointer text-base md:text-lg font-medium transition-colors ${
+                      isActive
+                        ? 'text-blue-700'
+                        : 'text-navy-950 hover:text-blue-700'
+                    }`
+                  }
+                >
+                  {t(`nav.${key}`, key.charAt(0).toUpperCase() + key.slice(1))}
+                </NavLink>
+              );
+            })}
+          </nav>
           <LanguageSwitcher />
-          {/* Mobile menu toggle */}
-          <div className="md:hidden">{/* ...burger menu... */}</div>
+        </div>
+
+        {/* Mobile: language and menu toggle */}
+        <div className="flex items-center space-x-4 md:hidden">
+          <LanguageSwitcher />
+          <div>{/* ...burger menu... */}</div>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- adjust navbar layout so navigation links align right next to language switcher
- show nav link titles capitalized by default
- add dropdown-based language switcher

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866823c14fc83339a3990281def600f