### PR TITLE
Improve language switcher and add IT translations

### DIFF
--- a/src/components/layout/LanguageSwitcher.tsx
+++ b/src/components/layout/LanguageSwitcher.tsx
@@ -31,11 +31,23 @@ const LanguageSwitcher = () => {
       </button>
       {open && (
         <div className="absolute right-0 mt-1 bg-white border rounded shadow-lg text-sm">
-          <div className={optionClass('it')} onClick={() => setLanguage('it')}>
+          <div
+            className={optionClass('it')}
+            onClick={() => {
+              setLanguage('it');
+              setOpen(false);
+            }}
+          >
             <span>🇮🇹</span>
             <span>IT</span>
           </div>
-          <div className={optionClass('en')} onClick={() => setLanguage('en')}>
+          <div
+            className={optionClass('en')}
+            onClick={() => {
+              setLanguage('en');
+              setOpen(false);
+            }}
+          >
             <span>🇬🇧</span>
             <span>EN</span>
           </div>

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -4,8 +4,10 @@ import { Mail, Phone, MapPin, ArrowRight } from "lucide-react";
 import SectionHeading from "../ui/SectionHeading";
 import Button from "../ui/Button";
 import ScrollAnimation from "../utils/ScrollAnimation";
+import { useLanguage } from "../../contexts/LanguageContext";
 
 const Contact = () => {
+  const { t } = useLanguage();
   const [formData, setFormData] = useState({
     user_name: "",
     user_email: "",
@@ -68,8 +70,11 @@ const Contact = () => {
     <section className="section bg-white">
       <div className="container">
         <SectionHeading
-          title="Contact & Booking"
-          subtitle="Ready to start saving? Get in touch for your free consultation"
+          title={t('contact.title', 'Contact & Booking')}
+          subtitle={t(
+            'contact.subtitle',
+            'Ready to start saving? Get in touch for your free consultation'
+          )}
         />
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
@@ -77,14 +82,16 @@ const Contact = () => {
           <ScrollAnimation animation="slide-up">
             <div className="bg-navy-950 text-white p-8 lg:p-12 rounded-lg shadow-xl">
               <h3 className="text-2xl font-bold mb-8 text-white">
-                Get In Touch
+                {t('contact.getInTouch', 'Get In Touch')}
               </h3>
 
               <div className="space-y-6">
                 <div className="flex items-start">
                   <Mail className="h-6 w-6 text-blue-400 mr-4 mt-1" />
                   <div>
-                    <h4 className="font-bold mb-1 text-white">Email</h4>
+                    <h4 className="font-bold mb-1 text-white">
+                      {t('contact.email', 'Email')}
+                    </h4>
                     <a
                       href="mailto:negotiation@dnego.com"
                       className="text-gray-300 hover:text-blue-400 transition-colors"
@@ -97,7 +104,9 @@ const Contact = () => {
                 <div className="flex items-start">
                   <Phone className="h-6 w-6 text-blue-400 mr-4 mt-1" />
                   <div>
-                    <h4 className="font-bold mb-1 text-white">Phone</h4>
+                    <h4 className="font-bold mb-1 text-white">
+                      {t('contact.phone', 'Phone')}
+                    </h4>
                     <a
                       href="tel:+393275859000"
                       className="text-gray-300 hover:text-blue-400 transition-colors"
@@ -110,10 +119,12 @@ const Contact = () => {
                 <div className="flex items-start">
                   <MapPin className="h-6 w-6 text-blue-400 mr-4 mt-1" />
                   <div>
-                    <h4 className="font-bold mb-1 text-white">Location</h4>
+                    <h4 className="font-bold mb-1 text-white">
+                      {t('contact.location', 'Location')}
+                    </h4>
                     <p className="text-gray-300">Parma, Italy</p>
                     <p className="text-gray-400">
-                      (Consultations available globally)
+                      {t('contact.locationNote', '(Consultations available globally)')}
                     </p>
                   </div>
                 </div>
@@ -121,17 +132,18 @@ const Contact = () => {
 
               <div className="mt-12">
                 <h4 className="text-xl font-bold mb-4 text-white">
-                  Upcoming Courses
+                  {t('contact.upcoming', 'Upcoming Courses')}
                 </h4>
                 <p className="text-gray-300 mb-4">
-                  DNego is developing online courses to train you in negotiation
-                  excellence. Enter your email in the form to receive updates
-                  and early access.
+                  {t(
+                    'contact.upcomingDesc',
+                    'DNego is developing online courses to train you in negotiation excellence. Enter your email in the form to receive updates and early access.'
+                  )}
                 </p>
                 <ul className="list-disc list-inside text-gray-300">
-                  <li>Advanced Negotiation Techniques</li>
-                  <li>Negotiation for Project Managers</li>
-                  <li>Supplier Management & Strategy</li>
+                  <li>{t('contact.course1', 'Advanced Negotiation Techniques')}</li>
+                  <li>{t('contact.course2', 'Negotiation for Project Managers')}</li>
+                  <li>{t('contact.course3', 'Supplier Management & Strategy')}</li>
                 </ul>
               </div>
             </div>
@@ -141,12 +153,12 @@ const Contact = () => {
           <ScrollAnimation animation="slide-up" delay={200}>
             <div className="bg-white p-8 lg:p-12 rounded-lg shadow-lg border">
               <h3 className="text-2xl font-bold mb-6 text-navy-950">
-                Send us a Message
+                {t('contact.formTitle', 'Send us a Message')}
               </h3>
 
               {submitted ? (
                 <div className="bg-green-100 border border-green-500 text-green-700 p-4 rounded-lg mb-4">
-                  Thank you for your message! We'll be in touch shortly.
+                  {t('contact.success', "Thank you for your message! We'll be in touch shortly.")}
                 </div>
               ) : null}
 
@@ -156,7 +168,7 @@ const Contact = () => {
                     htmlFor="name"
                     className="block text-gray-700 font-medium mb-2"
                   >
-                    Full Name
+                    {t('contact.nameLabel', 'Full Name')}
                   </label>
                   <input
                     type="text"
@@ -165,11 +177,13 @@ const Contact = () => {
                     value={formData.user_name}
                     onChange={handleChange}
                     onInvalid={(e) =>
-                      e.currentTarget.setCustomValidity("Please enter your full name")
+                      e.currentTarget.setCustomValidity(
+                        t('contact.nameInvalid', 'Please enter your full name')
+                      )
                     }
                     onInput={(e) => e.currentTarget.setCustomValidity("")}
                     className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-700 focus:border-blue-700 text-gray-900"
-                    placeholder="Your name"
+                    placeholder={t('contact.namePlaceholder', 'Your name')}
                     required
                   />
                 </div>
@@ -179,7 +193,7 @@ const Contact = () => {
                     htmlFor="email"
                     className="block text-gray-700 font-medium mb-2"
                   >
-                    Email Address
+                    {t('contact.emailLabel', 'Email Address')}
                   </label>
                   <input
                     type="email"
@@ -189,12 +203,12 @@ const Contact = () => {
                     onChange={handleChange}
                     onInvalid={(e) =>
                       e.currentTarget.setCustomValidity(
-                        "Please enter a valid email address"
+                        t('contact.emailInvalid', 'Please enter a valid email address')
                       )
                     }
                     onInput={(e) => e.currentTarget.setCustomValidity("")}
                     className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-700 focus:border-blue-700 text-gray-900"
-                    placeholder="your.email@example.com"
+                    placeholder={t('contact.emailPlaceholder', 'your.email@example.com')}
                     required
                   />
                 </div>
@@ -204,7 +218,7 @@ const Contact = () => {
                     htmlFor="message"
                     className="block text-gray-700 font-medium mb-2"
                   >
-                    Your Message
+                    {t('contact.messageLabel', 'Your Message')}
                   </label>
                   <textarea
                     id="message"
@@ -213,13 +227,13 @@ const Contact = () => {
                     onChange={handleChange}
                     onInvalid={(e) =>
                       e.currentTarget.setCustomValidity(
-                        "Please enter your message"
+                        t('contact.messageInvalid', 'Please enter your message')
                       )
                     }
                     onInput={(e) => e.currentTarget.setCustomValidity("")}
                     rows={5}
                     className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-700 focus:border-blue-700 text-gray-900"
-                    placeholder="How can we help you?"
+                    placeholder={t('contact.messagePlaceholder', 'How can we help you?')}
                     required
                   />
                 </div>
@@ -231,7 +245,7 @@ const Contact = () => {
                     className="h-4 w-4 text-blue-700 border-gray-300 rounded focus:ring-blue-700"
                     onInvalid={(e) =>
                       e.currentTarget.setCustomValidity(
-                        "You must agree to the privacy policy"
+                        t('contact.privacyInvalid', 'You must agree to the privacy policy')
                       )
                     }
                     onInput={(e) => e.currentTarget.setCustomValidity("")}
@@ -241,11 +255,11 @@ const Contact = () => {
                     htmlFor="privacy"
                     className="ml-2 block text-sm text-gray-700"
                   >
-                    I agree to the{" "}
+                    {t('contact.privacyText', 'I agree to the ')}{" "}
                     <a href="/privacy" className="text-blue-700 underline">
-                      privacy policy
+                      {t('contact.privacyPolicy', 'privacy policy')}
                     </a>{" "}
-                    and consent to being contacted regarding my inquiry.
+                    {t('contact.privacyContinue', 'and consent to being contacted regarding my inquiry.')}
                   </label>
                 </div>
 
@@ -258,7 +272,9 @@ const Contact = () => {
                   icon={ArrowRight}
                   iconPosition="right"
                 >
-                  {isSubmitting ? "Sending..." : "Send Message"}
+                  {isSubmitting
+                    ? t('contact.sending', 'Sending...')
+                    : t('contact.submit', 'Send Message')}
                 </Button>
               </form>
             </div>

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -63,6 +63,86 @@ const it = {
   'founder.section': 'Il Fondatore',
   'founder.about': 'Riguardo al Fondatore',
   'founder.bio1': 'Alexandru Buruiana vanta oltre cinque anni di esperienza internazionale nella negoziazione...',
+
+  // Contact
+  'contact.title': 'Contatti e Prenotazioni',
+  'contact.subtitle': 'Pronto a iniziare a risparmiare? Contattaci per una consulenza gratuita',
+  'contact.getInTouch': 'Contattaci',
+  'contact.email': 'Email',
+  'contact.phone': 'Telefono',
+  'contact.location': 'Località',
+  'contact.locationNote': '(Consulenze disponibili in tutto il mondo)',
+  'contact.upcoming': 'Prossimi Corsi',
+  'contact.upcomingDesc': 'DNego sta sviluppando corsi online per formarti all\'eccellenza nella negoziazione. Inserisci la tua email nel form per ricevere aggiornamenti e accesso anticipato.',
+  'contact.course1': 'Tecniche Avanzate di Negoziazione',
+  'contact.course2': 'Negoziare per Project Manager',
+  'contact.course3': 'Gestione e Strategia dei Fornitori',
+  'contact.formTitle': 'Invia un Messaggio',
+  'contact.success': 'Grazie per il messaggio! Ti ricontatteremo a breve.',
+  'contact.nameLabel': 'Nome Completo',
+  'contact.nameInvalid': 'Inserisci il tuo nome completo',
+  'contact.namePlaceholder': 'Il tuo nome',
+  'contact.emailLabel': 'Indirizzo Email',
+  'contact.emailInvalid': 'Inserisci un indirizzo email valido',
+  'contact.emailPlaceholder': 'tuo.email@example.com',
+  'contact.messageLabel': 'Il tuo Messaggio',
+  'contact.messageInvalid': 'Inserisci il messaggio',
+  'contact.messagePlaceholder': 'Come possiamo aiutarti?',
+  'contact.privacyInvalid': 'Devi accettare la privacy policy',
+  'contact.privacyText': 'Accetto la',
+  'contact.privacyPolicy': 'privacy policy',
+  'contact.privacyContinue': 'e acconsento a essere contattato per la mia richiesta.',
+  'contact.submit': 'Invia Messaggio',
+  'contact.sending': 'Invio...',
+
+  // About
+  'about.heroTitle': 'Chi è DNego',
+  'about.heroSubtitle': 'Siamo negoziatori esperti con la missione di aiutare i clienti a ottenere accordi migliori e risparmi significativi senza alcun rischio.',
+  'about.heroCta': 'Inizia Ora',
+  'about.storyTitle': 'La Nostra Storia',
+  'about.storyP1': 'DNego è stata fondata nel 2020 da Alexandru Buruiana dopo un decennio di esperienza negli acquisti aziendali. Dopo aver visto molte aziende pagare troppo per mancanza di competenze, Alexandru ha deciso di aiutare.',
+  'about.storyP2': 'Quella che era una consulenza individuale è cresciuta rapidamente grazie ai risultati. Oggi DNego collabora con organizzazioni di diversi settori offrendo risparmi misurabili con il nostro modello a performance.',
+  'about.storyP3': 'Abbiamo aiutato i clienti a risparmiare milioni tramite negoziazioni migliori, guadagnando solo dai risultati. Il nostro team unisce esperienza aziendale e competenze specialistiche per risultati eccezionali.',
+  'about.missionTitle': 'La Nostra Missione',
+  'about.missionSubtitle': "Democratizzare l'accesso alla negoziazione professionale eliminando il rischio finanziario",
+  'about.mission1Title': 'Rendere Accessibile la Negoziazione Esperta',
+  'about.mission1Desc': 'Crediamo che tutti meritino supporto professionale nelle trattative, indipendentemente da dimensioni o budget.',
+  'about.mission2Title': 'Allineare Perfettamente gli Incentivi',
+  'about.mission2Desc': 'Il nostro successo è legato al tuo: vinciamo solo quando risparmi denaro, creando un perfetto allineamento.',
+  'about.mission3Title': 'Mantenere i Massimi Standard Etici',
+  'about.mission3Desc': 'Negotiamo con determinazione ma in modo etico, costruendo relazioni anziché bruciare ponti.',
+  'about.valuesTitle': 'I Nostri Valori',
+  'about.valuesSubtitle': 'I principi che guidano ogni nostra azione',
+  'about.value1Title': 'Trasparenza',
+  'about.value1Desc': 'Crediamo nella piena apertura di approccio, metodi e compensi. Saprai sempre come procediamo.',
+  'about.value2Title': 'Orientamento ai Risultati',
+  'about.value2Desc': 'Siamo ossessionati dai risultati misurabili. Tutto ciò che facciamo mira a massimizzare i risparmi e migliorare i termini.',
+  'about.value3Title': 'Integrità',
+  'about.value3Desc': 'Manteniamo i più alti standard etici in ogni trattativa. La nostra reputazione e la tua sono ugualmente importanti.',
+  'about.value4Title': 'Apprendimento Continuo',
+  'about.value4Desc': 'Ci impegniamo a migliorare costantemente conoscenze e competenze per offrire risultati sempre migliori.',
+  'about.ctaTitle': 'Pronto a Iniziare a Risparmiare?',
+  'about.ctaSubtitle': 'Contattaci oggi per una consulenza gratuita e scopri quanto puoi risparmiare.',
+  'about.ctaButton': 'Prenota la Tua Consulenza Gratuita',
+
+  // Services
+  'services.heroTitle': 'I Nostri Servizi',
+  'services.heroSubtitle': 'Competenza di negoziazione specializzata in ambito immobiliare, carriera e consulenza aziendale. Abbiamo successo solo quando risparmi.',
+  'services.heroCta': 'Ottieni la tua consulenza gratuita',
+
+  // Blog
+  'blog.title': 'Tutti gli Articoli del Blog',
+  'blog.subtitle': 'Scopri tutti i nostri ultimi approfondimenti su negoziazione, strategia e creazione di valore.',
+  'blog.readArticle': 'Leggi l\'articolo',
+  'blog.back': 'Torna al Blog',
+
+  // Terms
+  'terms.title': 'Termini di Servizio',
+  'terms.subtitle': 'Leggi attentamente questi termini prima di utilizzare i nostri servizi.',
+
+  // Privacy
+  'privacy.title': 'Informativa sulla Privacy',
+  'privacy.subtitle': 'Data di efficacia: 3 luglio 2025'
 };
 
 export default it;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,8 +1,10 @@
 import SectionHeading from '../components/ui/SectionHeading';
 import ScrollAnimation from '../components/utils/ScrollAnimation';
 import Button from '../components/ui/Button';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const About = () => {
+  const { t } = useLanguage();
   return (
     <div className="pt-24 bg-white">
       {/* Hero */}
@@ -10,16 +12,17 @@ const About = () => {
         <div className="container">
           <div className="max-w-3xl mx-auto text-center">
             <ScrollAnimation animation="slide-up">
-              <h1 className="text-4xl md:text-5xl font-bold mb-6 text-white">About DNego</h1>
+              <h1 className="text-4xl md:text-5xl font-bold mb-6 text-white">
+                {t('about.heroTitle', 'About DNego')}
+              </h1>
               <p className="text-xl text-gray-300 mb-6">
-                We are expert negotiators with a mission to help clients achieve better deals and significant savings with absolutely no risk.
+                {t(
+                  'about.heroSubtitle',
+                  'We are expert negotiators with a mission to help clients achieve better deals and significant savings with absolutely no risk.'
+                )}
               </p>
-              <Button 
-                variant="primary" 
-                size="lg" 
-                href="/contact"
-              >
-                Get Started
+              <Button variant="primary" size="lg" href="/contact">
+                {t('about.heroCta', 'Get Started')}
               </Button>
             </ScrollAnimation>
           </div>
@@ -39,15 +42,26 @@ const About = () => {
             </ScrollAnimation>
             
             <ScrollAnimation animation="slide-up">
-              <h2 className="text-3xl font-bold mb-6 text-navy-950">Our Story</h2>
+              <h2 className="text-3xl font-bold mb-6 text-navy-950">
+                {t('about.storyTitle', 'Our Story')}
+              </h2>
               <p className="text-gray-600 mb-4">
-                DNego was founded in 2020 by Alexandru Buruiana after a decade of corporate procurement experience. Having witnessed countless negotiations where businesses overpaid due to lack of expertise or resources, Alexandru saw an opportunity to help.
+                {t(
+                  'about.storyP1',
+                  'DNego was founded in 2020 by Alexandru Buruiana after a decade of corporate procurement experience. Having witnessed countless negotiations where businesses overpaid due to lack of expertise or resources, Alexandru saw an opportunity to help.'
+                )}
               </p>
               <p className="text-gray-600 mb-4">
-                What began as a solo consulting practice quickly grew as clients experienced the power of professional negotiation. Today, DNego works with organizations across industries, delivering measurable savings with our unique performance-based model.
+                {t(
+                  'about.storyP2',
+                  'What began as a solo consulting practice quickly grew as clients experienced the power of professional negotiation. Today, DNego works with organizations across industries, delivering measurable savings with our unique performance-based model.'
+                )}
               </p>
               <p className="text-gray-700 font-medium">
-                We've helped clients save millions through better negotiation, earning our fee only from actual results. Our growing team combines corporate experience with specialized industry knowledge to deliver exceptional outcomes.
+                {t(
+                  'about.storyP3',
+                  "We've helped clients save millions through better negotiation, earning our fee only from actual results. Our growing team combines corporate experience with specialized industry knowledge to deliver exceptional outcomes."
+                )}
               </p>
             </ScrollAnimation>
           </div>
@@ -58,8 +72,11 @@ const About = () => {
       <section className="section bg-gray-50">
         <div className="container">
           <SectionHeading
-            title="Our Mission"
-            subtitle="To democratize access to expert negotiation services by removing financial risk"
+            title={t('about.missionTitle', 'Our Mission')}
+            subtitle={t(
+              'about.missionSubtitle',
+              'To democratize access to expert negotiation services by removing financial risk'
+            )}
           />
           
           <div className="bg-white rounded-lg shadow-lg p-8 md:p-12">
@@ -69,9 +86,14 @@ const About = () => {
                   <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-100 text-blue-700 rounded-full mb-4">
                     <span className="text-2xl font-bold">1</span>
                   </div>
-                  <h3 className="text-xl font-bold mb-3 text-navy-950">Make Expert Negotiation Accessible</h3>
+                  <h3 className="text-xl font-bold mb-3 text-navy-950">
+                    {t('about.mission1Title', 'Make Expert Negotiation Accessible')}
+                  </h3>
                   <p className="text-gray-600">
-                    We believe everyone deserves access to professional negotiation support, regardless of size or budget.
+                    {t(
+                      'about.mission1Desc',
+                      'We believe everyone deserves access to professional negotiation support, regardless of size or budget.'
+                    )}
                   </p>
                 </div>
                 
@@ -79,9 +101,14 @@ const About = () => {
                   <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-100 text-blue-700 rounded-full mb-4">
                     <span className="text-2xl font-bold">2</span>
                   </div>
-                  <h3 className="text-xl font-bold mb-3 text-navy-950">Align Incentives Perfectly</h3>
+                  <h3 className="text-xl font-bold mb-3 text-navy-950">
+                    {t('about.mission2Title', 'Align Incentives Perfectly')}
+                  </h3>
                   <p className="text-gray-600">
-                    Our success is directly tied to yours. We only win when you save money, creating perfect alignment.
+                    {t(
+                      'about.mission2Desc',
+                      'Our success is directly tied to yours. We only win when you save money, creating perfect alignment.'
+                    )}
                   </p>
                 </div>
                 
@@ -89,9 +116,14 @@ const About = () => {
                   <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-100 text-blue-700 rounded-full mb-4">
                     <span className="text-2xl font-bold">3</span>
                   </div>
-                  <h3 className="text-xl font-bold mb-3 text-navy-950">Maintain Highest Ethics</h3>
+                  <h3 className="text-xl font-bold mb-3 text-navy-950">
+                    {t('about.mission3Title', 'Maintain Highest Ethics')}
+                  </h3>
                   <p className="text-gray-600">
-                    We negotiate hard but ethically, building relationships rather than burning bridges.
+                    {t(
+                      'about.mission3Desc',
+                      'We negotiate hard but ethically, building relationships rather than burning bridges.'
+                    )}
                   </p>
                 </div>
               </div>
@@ -104,43 +136,51 @@ const About = () => {
       <section className="section bg-white">
         <div className="container">
           <SectionHeading
-            title="Our Values"
-            subtitle="The principles that guide everything we do"
+            title={t('about.valuesTitle', 'Our Values')}
+            subtitle={t('about.valuesSubtitle', 'The principles that guide everything we do')}
           />
           
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             <ScrollAnimation animation="slide-up">
               <div className="bg-white p-8 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300 h-full border">
-                <h3 className="text-xl font-bold mb-3 text-navy-950">Transparency</h3>
+                <h3 className="text-xl font-bold mb-3 text-navy-950">
+                  {t('about.value1Title', 'Transparency')}
+                </h3>
                 <p className="text-gray-600">
-                  We believe in complete openness in our approach, methods, and fee structure. You'll always know exactly where you stand and how we're approaching your negotiation.
+                  {t('about.value1Desc', "We believe in complete openness in our approach, methods, and fee structure. You'll always know exactly where you stand and how we're approaching your negotiation.")}
                 </p>
               </div>
             </ScrollAnimation>
             
             <ScrollAnimation animation="slide-up" delay={100}>
               <div className="bg-white p-8 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300 h-full border">
-                <h3 className="text-xl font-bold mb-3 text-navy-950">Results-Focus</h3>
+                <h3 className="text-xl font-bold mb-3 text-navy-950">
+                  {t('about.value2Title', 'Results-Focus')}
+                </h3>
                 <p className="text-gray-600">
-                  We're obsessed with achieving measurable results. Everything we do is designed to maximize your savings and improve your deal terms.
+                  {t('about.value2Desc', "We're obsessed with achieving measurable results. Everything we do is designed to maximize your savings and improve your deal terms.")}
                 </p>
               </div>
             </ScrollAnimation>
             
             <ScrollAnimation animation="slide-up" delay={200}>
               <div className="bg-white p-8 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300 h-full border">
-                <h3 className="text-xl font-bold mb-3 text-navy-950">Integrity</h3>
+                <h3 className="text-xl font-bold mb-3 text-navy-950">
+                  {t('about.value3Title', 'Integrity')}
+                </h3>
                 <p className="text-gray-600">
-                  We maintain the highest ethical standards in all negotiations. Our reputation and yours are equally important to us.
+                  {t('about.value3Desc', 'We maintain the highest ethical standards in all negotiations. Our reputation and yours are equally important to us.')}
                 </p>
               </div>
             </ScrollAnimation>
             
             <ScrollAnimation animation="slide-up" delay={300}>
               <div className="bg-white p-8 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300 h-full border">
-                <h3 className="text-xl font-bold mb-3 text-navy-950">Continuous Learning</h3>
+                <h3 className="text-xl font-bold mb-3 text-navy-950">
+                  {t('about.value4Title', 'Continuous Learning')}
+                </h3>
                 <p className="text-gray-600">
-                  We're committed to constantly improving our knowledge and skills to deliver even better results for our clients.
+                  {t('about.value4Desc', "We're committed to constantly improving our knowledge and skills to deliver even better results for our clients.")}
                 </p>
               </div>
             </ScrollAnimation>
@@ -153,16 +193,17 @@ const About = () => {
         <div className="container">
           <div className="max-w-3xl mx-auto text-center">
             <ScrollAnimation animation="fade-in">
-              <h2 className="text-3xl md:text-4xl font-bold mb-6 text-white">Ready to Start Saving?</h2>
+              <h2 className="text-3xl md:text-4xl font-bold mb-6 text-white">
+                {t('about.ctaTitle', 'Ready to Start Saving?')}
+              </h2>
               <p className="text-xl text-gray-300 mb-8">
-                Contact us today for your free consultation and see how much we can save you.
+                {t(
+                  'about.ctaSubtitle',
+                  'Contact us today for your free consultation and see how much we can save you.'
+                )}
               </p>
-              <Button 
-                variant="primary" 
-                size="lg" 
-                href="/contact"
-              >
-                Schedule Your Free Consultation
+              <Button variant="primary" size="lg" href="/contact">
+                {t('about.ctaButton', 'Schedule Your Free Consultation')}
               </Button>
             </ScrollAnimation>
           </div>

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -5,8 +5,10 @@ import { Card, CardBody } from '../components/ui/Card'
 import Button from '../components/ui/Button'
 import SectionHeading from '../components/ui/SectionHeading'
 import ScrollAnimation from '../components/utils/ScrollAnimation'
+import { useLanguage } from '../contexts/LanguageContext'
 
 const Blog: React.FC = () => {
+  const { t } = useLanguage()
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }, [])
@@ -16,8 +18,8 @@ const Blog: React.FC = () => {
     <section className="section">
       <div className="container">
         <SectionHeading
-          title="All Blog Articles"
-          subtitle="Explore all our latest insights on negotiation, strategy, and value creation."
+          title={t('blog.title', 'All Blog Articles')}
+          subtitle={t('blog.subtitle', 'Explore all our latest insights on negotiation, strategy, and value creation.')}
         />
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
@@ -49,7 +51,7 @@ const Blog: React.FC = () => {
                       size="sm"
                       className="mt-2"
                     >
-                      Read Article
+                      {t('blog.readArticle', 'Read Article')}
                     </Button>
                   </div>
                 </CardBody>

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -4,8 +4,10 @@ import { useParams, Navigate } from 'react-router-dom'
 import posts, { Post } from '../data/posts'
 import { Calendar, Clock, Tag } from 'lucide-react'
 import Button from '../components/ui/Button'
+import { useLanguage } from '../contexts/LanguageContext'
 
 const BlogPost: React.FC = () => {
+  const { t } = useLanguage()
   const { slug } = useParams<{ slug: string }>()
   const post: Post | undefined = posts.find(p => p.slug === slug)
 
@@ -26,7 +28,9 @@ const BlogPost: React.FC = () => {
         dangerouslySetInnerHTML={{ __html: post.content }}
       />
       <div className="mt-12">
-        <Button href="/blog" variant="outline">← Back to Blog</Button>
+        <Button href="/blog" variant="outline">
+          ← {t('blog.back', 'Back to Blog')}
+        </Button>
       </div>
     </article>
   )

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,6 +1,8 @@
 import ScrollAnimation from '../components/utils/ScrollAnimation';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const Privacy = () => {
+  const { t } = useLanguage();
   return (
     <div className="pt-24 bg-white">
       {/* Hero */}
@@ -9,9 +11,11 @@ const Privacy = () => {
           <div className="max-w-3xl mx-auto text-center">
             <ScrollAnimation animation="slide-up">
               <h1 className="text-4xl md:text-5xl font-bold mb-6 text-white">
-                Privacy Policy
+                {t('privacy.title', 'Privacy Policy')}
               </h1>
-              <p className="text-xl text-gray-300 mb-6">Effective Date: 3 luglio 2025</p>
+              <p className="text-xl text-gray-300 mb-6">
+                {t('privacy.subtitle', 'Effective Date: 3 luglio 2025')}
+              </p>
             </ScrollAnimation>
           </div>
         </div>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -4,6 +4,7 @@ import { Home, DollarSign, Handshake, ArrowRight, CheckCircle } from 'lucide-rea
 import SectionHeading from '../components/ui/SectionHeading';
 import ScrollAnimation from '../components/utils/ScrollAnimation';
 import Button from '../components/ui/Button';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const services = [
   {
@@ -84,6 +85,7 @@ const services = [
 ];
 
 const Services = () => {
+  const { t } = useLanguage();
   const location = useLocation();
 
   useEffect(() => {
@@ -107,16 +109,17 @@ const Services = () => {
         <div className="container">
           <div className="max-w-3xl mx-auto text-center">
             <ScrollAnimation animation="slide-up">
-              <h1 className="text-4xl md:text-5xl font-bold mb-6 text-white">Our Services</h1>
+              <h1 className="text-4xl md:text-5xl font-bold mb-6 text-white">
+                {t('services.heroTitle', 'Our Services')}
+              </h1>
               <p className="text-xl text-gray-300 mb-6">
-                Specialized negotiation expertise across real estate, career advancement, and business consulting. We only succeed when you save money.
+                {t(
+                  'services.heroSubtitle',
+                  'Specialized negotiation expertise across real estate, career advancement, and business consulting. We only succeed when you save money.'
+                )}
               </p>
-              <Button 
-                variant="primary" 
-                size="lg" 
-                href="/contact"
-              >
-                Get Your Free Consultation
+              <Button variant="primary" size="lg" href="/contact">
+                {t('services.heroCta', 'Get Your Free Consultation')}
               </Button>
             </ScrollAnimation>
           </div>

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,6 +1,8 @@
 import ScrollAnimation from '../components/utils/ScrollAnimation';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const Terms = () => {
+  const { t } = useLanguage();
   return (
     <div className="pt-24 bg-white">
       {/* Hero */}
@@ -9,10 +11,10 @@ const Terms = () => {
           <div className="max-w-3xl mx-auto text-center">
             <ScrollAnimation animation="slide-up">
               <h1 className="text-4xl md:text-5xl font-bold mb-6 text-white">
-                Terms of Service
+                {t('terms.title', 'Terms of Service')}
               </h1>
               <p className="text-xl text-gray-300 mb-6">
-                Please read these terms carefully before using our services.
+                {t('terms.subtitle', 'Please read these terms carefully before using our services.')}
               </p>
             </ScrollAnimation>
           </div>


### PR DESCRIPTION
## Summary
- close dropdown when selecting language
- translate contact section, about page, blog pages, services hero, terms and privacy headers
- expand Italian translation file

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68668491c05083338198e8320d58aa4d