### PR TITLE
Improve hero contrast

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -33,7 +33,7 @@ const Hero: React.FC = () => {
           </ScrollAnimation>
 
           <ScrollAnimation animation="slide-up" delay={300}>
-            <p className="text-sm md:text-base text-gray-700 mb-8">
+            <p className="text-sm md:text-base text-black mb-8">
               {t('hero.subtitle', 'Our compensation is solely a share of the savings we deliver')}
             </p>
           </ScrollAnimation>
@@ -54,7 +54,7 @@ const Hero: React.FC = () => {
                 variant="outline"
                 size="lg"
                 href="/services"
-                className="border-navy-950 text-navy-950 hover:bg-navy-950 hover:text-white"
+                className="border-black text-black hover:bg-black hover:text-white"
               >
                 {t('hero.secondary', 'View Services')}
               </Button>
@@ -68,7 +68,7 @@ const Hero: React.FC = () => {
       <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 animate-bounce">
         <a
           href="#why-choose-us"
-          className="flex flex-col items-center text-navy-950 hover:opacity-80 transition-opacity"
+          className="flex flex-col items-center text-black hover:opacity-80 transition-opacity"
         >
           <span className="text-sm mb-1">{t('hero.scroll', 'Scroll')}</span>
           <svg


### PR DESCRIPTION
## Summary
- darken hero subtitle
- darken the "View Services" button styling
- make scroll indicator text and arrow black

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d1915b65c83339ba50871ac9a7c3b