### PR TITLE
Lighten hero overlay

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -14,13 +14,13 @@ const Hero: React.FC = () => {
       <div
         className="absolute inset-y-0 left-0 w-1/2 pointer-events-none"
         style={{
-          background: 'linear-gradient(to right, rgba(0,0,0,0.4), rgba(0,0,0,0))',
+          background: 'linear-gradient(to right, rgba(0,0,0,0.15), rgba(0,0,0,0))',
         }}
       />
 
       {/* Contenuto centrato verticalmente */}
       <div className="relative container mx-auto px-6 grid grid-cols-1 md:grid-cols-2 items-center">
-        <div className="max-w-lg">
+        <div className="max-w-lg text-shadow">
           <ScrollAnimation animation="fade-in">
             <h1 className="text-2xl md:text-3xl lg:text-4xl font-semibold text-navy-950 mb-4">
               {t('hero.title', 'The art of negotiation at your service, for a fair deal')}

--- a/src/index.css
+++ b/src/index.css
@@ -99,4 +99,8 @@
   .slide-up.appear {
     @apply translate-y-0 opacity-100;
   }
+
+  .text-shadow {
+    text-shadow: 0 1px 2px rgba(0,0,0,0.1);
+  }
 }


### PR DESCRIPTION
## Summary
- lighten the hero section overlay for better background visibility
- add a subtle text-shadow utility and use it for hero text

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d1c80261083339d4ba55febfb6fff