### PR TITLE
Adjust hero gradient transparency

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -12,7 +12,7 @@ const Hero: React.FC = () => {
     >
       {/* Overlay per migliorare la leggibilità del testo */}
       <div
-        className="absolute inset-y-0 left-0 w-2/3 pointer-events-none bg-gradient-to-r from-white/95 via-white/75 to-transparent"
+        className="absolute inset-y-0 left-0 w-2/3 pointer-events-none bg-gradient-to-r from-white/95 via-white/60 to-transparent"
       />
 
       {/* Contenuto centrato verticalmente */}


### PR DESCRIPTION
## Summary
- tweak hero section gradient to fade out sooner

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d29c19b6c8333b74521d29802d77d