### PR TITLE
Update hero overlay and highlight text

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -12,7 +12,7 @@ const Hero: React.FC = () => {
     >
       {/* Overlay per migliorare la leggibilità del testo */}
       <div
-        className="absolute inset-y-0 left-0 w-2/3 pointer-events-none bg-gradient-to-r from-white/95 via-white/10 to-transparent"
+        className="absolute inset-0 pointer-events-none bg-gradient-to-r from-white/70 via-white/20 to-transparent"
       />
 
       {/* Contenuto centrato verticalmente */}
@@ -30,7 +30,11 @@ const Hero: React.FC = () => {
 
           <ScrollAnimation animation="slide-up" delay={300}>
             <p className="text-sm md:text-base text-black mb-8">
-              {t('hero.subtitle', 'Our compensation is solely a share of the savings we deliver')}
+              {t('hero.subtitle.part1', 'Our compensation is solely a share of the savings we ')}
+              <span className="bg-black/40 text-white px-1 rounded">
+                {t('hero.subtitle.highlight', 'deliver')}
+              </span>
+              {t('hero.subtitle.part2', '')}
             </p>
           </ScrollAnimation>
 

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -19,7 +19,9 @@ const it = {
 
   // Hero
   'hero.title': 'L\'arte della negoziazione al tuo servizio, per un accordo equo',
-  'hero.subtitle': 'Il nostro compenso è una percentuale dei risparmi che ti facciamo guadagnare',
+  'hero.subtitle.part1': 'Il nostro compenso è una percentuale dei risparmi che ti ',
+  'hero.subtitle.highlight': 'facciamo',
+  'hero.subtitle.part2': ' guadagnare',
   'hero.cta': 'Consulenza Gratuita',
   'hero.secondary': 'Scopri i Servizi',
   'hero.scroll': 'Scorri',


### PR DESCRIPTION
## Summary
- highlight `facciamo` in the hero subtitle on a darker background
- extend the hero overlay gradient for better readability
- add new Italian translation segments for the updated subtitle

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d2d88e27c8333805dcecdd31f6a46