### PR TITLE
Add blue background to hero text and button

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -16,7 +16,7 @@ const Hero: React.FC = () => {
       <div className="relative container mx-auto px-6 grid grid-cols-1 md:grid-cols-2 items-center">
         <div className="max-w-lg text-shadow">
           <ScrollAnimation animation="fade-in">
-            <h1 className="text-2xl md:text-3xl lg:text-4xl font-semibold text-white mb-4">
+            <h1 className="text-2xl md:text-3xl lg:text-4xl font-semibold text-white mb-4 bg-blue-900/40 p-2 rounded">
               {t('hero.title', 'The art of negotiation at your service, for a fair deal')}
             </h1>
           </ScrollAnimation>
@@ -26,7 +26,7 @@ const Hero: React.FC = () => {
           </ScrollAnimation>
 
           <ScrollAnimation animation="slide-up" delay={300}>
-            <p className="text-sm md:text-base text-white mb-8">
+            <p className="text-sm md:text-base text-white mb-8 bg-blue-900/40 p-2 rounded">
               {t('hero.subtitle', 'Our compensation is solely a share of the savings we deliver')}
             </p>
           </ScrollAnimation>
@@ -44,10 +44,10 @@ const Hero: React.FC = () => {
                 {t('hero.cta', 'Free Consultation')}
               </Button>
               <Button
-                variant="outline"
+                variant="primary"
                 size="lg"
                 href="/services"
-                className="border-white text-white hover:bg-white hover:text-black"
+                className="bg-blue-900/40 hover:bg-blue-900/60"
               >
                 {t('hero.secondary', 'View Services')}
               </Button>


### PR DESCRIPTION
## Summary
- make the hero heading and subtitle easier to read with a translucent blue background
- give the "Scopri i servizi" button a matching blue tint

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d339ddea08333ab93df167bfbbb22