### PR TITLE
Improve hero background layout

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -14,9 +14,9 @@ const Hero: React.FC = () => {
 
       {/* Contenuto centrato verticalmente */}
       <div className="relative container mx-auto px-6 grid grid-cols-1 md:grid-cols-2 items-center">
-        <div className="max-w-lg text-shadow">
+        <div className="max-w-lg inline-block text-shadow bg-blue-900/40 p-4 rounded-lg">
           <ScrollAnimation animation="fade-in">
-            <h1 className="text-2xl md:text-3xl lg:text-4xl font-semibold text-white mb-4 bg-blue-900/40 p-2 rounded">
+            <h1 className="text-2xl md:text-3xl lg:text-4xl font-semibold text-white mb-4">
               {t('hero.title', 'The art of negotiation at your service, for a fair deal')}
             </h1>
           </ScrollAnimation>
@@ -26,7 +26,7 @@ const Hero: React.FC = () => {
           </ScrollAnimation>
 
           <ScrollAnimation animation="slide-up" delay={300}>
-            <p className="text-sm md:text-base text-white mb-8 bg-blue-900/40 p-2 rounded">
+            <p className="text-sm md:text-base text-white mb-8">
               {t('hero.subtitle', 'Our compensation is solely a share of the savings we deliver')}
             </p>
           </ScrollAnimation>


### PR DESCRIPTION
## Summary
- keep the hero's background color but reduce its footprint
- wrap the hero text and buttons with padding and rounded corners

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d358a65ec833396038a372e380264