### PR TITLE
Add hero text wrapper

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -14,7 +14,8 @@ const Hero: React.FC = () => {
 
       {/* Contenuto centrato verticalmente */}
       <div className="relative container mx-auto px-6 grid grid-cols-1 md:grid-cols-2 items-center">
-        <div className="max-w-lg inline-block text-shadow bg-blue-900/40 p-4 rounded-lg">
+        <div className="max-w-lg">
+          <div className="hero-text-wrapper">
           <ScrollAnimation animation="fade-in">
             <h1 className="text-2xl md:text-3xl lg:text-4xl font-semibold text-white mb-4">
               {t('hero.title', 'The art of negotiation at your service, for a fair deal')}
@@ -53,6 +54,7 @@ const Hero: React.FC = () => {
               </Button>
             </div>
           </ScrollAnimation>
+          </div>
         </div>
         <div /> {/* Vuoto per mantenere due colonne */}
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -103,4 +103,8 @@
   .text-shadow {
     text-shadow: 0 1px 2px rgba(0,0,0,0.1);
   }
+
+  .hero-text-wrapper {
+    @apply inline-block py-4 px-6 rounded-lg bg-black/40 text-white text-shadow;
+  }
 }


### PR DESCRIPTION
## Summary
- add `.hero-text-wrapper` utility to style semi-transparent hero text block
- wrap Home hero text and buttons with this new class

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d36ae6648833393f4ef4b5d5b0d63