### PR TITLE
Update hero heading backgrounds

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -17,8 +17,10 @@ const Hero: React.FC = () => {
       <div className="relative container mx-auto px-6 grid grid-cols-1 md:grid-cols-2 items-center">
         <div className="max-w-lg text-shadow">
           <ScrollAnimation animation="fade-in">
-            <h1 className="text-2xl md:text-3xl lg:text-4xl font-semibold text-white mb-4 bg-blue-900/40 p-2 rounded">
-              {t('hero.title', 'The art of negotiation at your service, for a fair deal')}
+            <h1 className="text-2xl md:text-3xl lg:text-4xl font-semibold text-white mb-4">
+              <span className="hero-title-bg">
+                {t('hero.title', 'The art of negotiation at your service, for a fair deal')}
+              </span>
             </h1>
           </ScrollAnimation>
 
@@ -27,8 +29,10 @@ const Hero: React.FC = () => {
           </ScrollAnimation>
 
           <ScrollAnimation animation="slide-up" delay={300}>
-            <p className="text-sm md:text-base text-white mb-8 bg-blue-900/40 p-2 rounded">
-              {t('hero.subtitle', 'Our compensation is solely a share of the savings we deliver')}
+            <p className="text-sm md:text-base text-white mb-8">
+              <span className="hero-subtitle-bg">
+                {t('hero.subtitle', 'Our compensation is solely a share of the savings we deliver')}
+              </span>
             </p>
           </ScrollAnimation>
 

--- a/src/index.css
+++ b/src/index.css
@@ -103,4 +103,12 @@
   .text-shadow {
     text-shadow: 0 1px 2px rgba(0,0,0,0.1);
   }
+
+  .hero-title-bg,
+  .hero-subtitle-bg {
+    display: inline-block;
+    background-color: rgba(0,0,0,0.5);
+    padding: 0.3em 0.6em;
+    border-radius: 0.25em;
+  }
 }


### PR DESCRIPTION
## Summary
- keep hero heading backgrounds only around text
- add classes for inline-block hero backgrounds

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e145ed03083338ac9bafd49fe7b26