### PR TITLE
Revert hero layout tweaks

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -17,7 +17,7 @@ const Hero: React.FC = () => {
       <div className="relative container mx-auto px-6 grid grid-cols-1 md:grid-cols-2 items-center">
         <div className="max-w-lg text-shadow">
           <ScrollAnimation animation="fade-in">
-            <h1 className="inline-block w-fit text-2xl md:text-3xl lg:text-4xl font-semibold text-white mb-4 bg-blue-900/40 px-3 py-1 rounded">
+            <h1 className="text-2xl md:text-3xl lg:text-4xl font-semibold text-white mb-4 bg-blue-900/40 p-2 rounded">
               {t('hero.title', 'The art of negotiation at your service, for a fair deal')}
             </h1>
           </ScrollAnimation>
@@ -27,7 +27,7 @@ const Hero: React.FC = () => {
           </ScrollAnimation>
 
           <ScrollAnimation animation="slide-up" delay={300}>
-            <p className="inline-block w-fit text-sm md:text-base text-white mb-8 bg-blue-900/40 px-3 py-1 rounded">
+            <p className="text-sm md:text-base text-white mb-8 bg-blue-900/40 p-2 rounded">
               {t('hero.subtitle', 'Our compensation is solely a share of the savings we deliver')}
             </p>
           </ScrollAnimation>


### PR DESCRIPTION
## Summary
- revert hero background sizing change

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e18ef4c8c8333b195c678ed6d98ca