### PR TITLE
Reduce spacing for final founder paragraph

### DIFF
--- a/src/components/sections/Founder.tsx
+++ b/src/components/sections/Founder.tsx
@@ -49,7 +49,7 @@ const Founder = () => {
         
         {/* Bio4 paragraph - full width below the image and text */}
         <ScrollAnimation animation="slide-up" delay={200}>
-          <div className="mt-6">
+          <div className="mt-2">
             <p className="text-gray-700 font-medium">
               {t(
                 'founder.bio4', 'I love finding the right balance between quality and price, because I believe that every agreement should reflect not just a good economic outcome, but also the values of those who sign it: transparency, integrity, and respect. I\'m convinced that a good negotiation is never about one side winning over the other, but about building an agreement where both parties feel acknowledged and fulfilled.'


### PR DESCRIPTION
## Summary
- tweak spacing before founder's final paragraph for better layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68724fbe6bcc83338277870cac96e1a9