### PR TITLE
Fix About section alignment

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -32,7 +32,7 @@ const About = () => {
       {/* Our Story */}
       <section className="section bg-white">
         <div className="container">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-12 items-start">
             <ScrollAnimation animation="fade-in">
               <img 
                 src="https://images.pexels.com/photos/3183197/pexels-photo-3183197.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750"


### PR DESCRIPTION
## Summary
- ensure the image and text start at the same top edge in the About page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68725334cb088333ad322b5d5235865f