### PR TITLE
Fix alignment for how-it-works cards

### DIFF
--- a/src/components/sections/HowItWorks.tsx
+++ b/src/components/sections/HowItWorks.tsx
@@ -60,10 +60,10 @@ const HowItWorks = () => {
                   </div>
                   
                   {/* Content */}
-                  <div className={`md:w-1/2 ${index % 2 === 0 ? 'md:pl-12' : 'md:pr-12 text-right'}`}>
+                  <div className={`md:w-1/2 ${index % 2 === 0 ? 'md:pl-12' : 'md:pr-12'}`}>
                     <div className="bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300 border">
-                      <div className={`flex items-center mb-4 ${index % 2 === 1 ? 'md:justify-end' : ''}`}>
-                        <step.icon className={`h-8 w-8 text-blue-700 ${index % 2 === 0 ? 'mr-4' : 'md:order-2 md:ml-4'}`} />
+                      <div className="flex items-center mb-4">
+                        <step.icon className="h-8 w-8 text-blue-700 mr-4" />
                         <h3 className="text-xl font-bold text-navy-950">{t(`how.step${index+1}.title`, step.title)}</h3>
                       </div>
                       <p className="text-gray-600">{t(`how.step${index+1}.desc`, step.description)}</p>


### PR DESCRIPTION
## Summary
- align step cards 2 and 4 to the left so their text and icons no longer right-align

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68737a4a2f20833398063bf1fb5b20ed