### PR TITLE
Fix cross-cultural blog image size

### DIFF
--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -27,7 +27,8 @@ const BlogPost: React.FC = () => {
         alt={post.title}
         className={
           post.slug === 'avoiding-common-pitfalls' ||
-          post.slug === 'psychology-of-negotiation'
+          post.slug === 'psychology-of-negotiation' ||
+          post.slug === 'cross-cultural-strategies'
             ?
                 'w-full h-auto md:max-h-[20rem] object-cover rounded-lg mb-4 md:float-right md:ml-6'
             :


### PR DESCRIPTION
## Summary
- match the lead image size of "Global Deal-Making: Cross-Cultural Strategies" to the one used for "The Psychology of Negotiation"

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6873af74d00c8333a9afbe58e561b562