### PR TITLE
Refactor hero section layout

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -7,91 +7,47 @@ import { useLanguage } from '../../contexts/LanguageContext';
 const Hero: React.FC = () => {
   const { t } = useLanguage();
   return (
-    <section
-      className="relative bg-cover bg-center bg-no-repeat h-screen flex items-center"
-      style={{ backgroundImage: "url('/hero.jpg')" }}
-    >
-      {/* Rimosso overlay per rendere visibile l'immagine senza trasparenze */}
-
-      {/* Contenuto centrato verticalmente */}
-      <div className="relative container mx-auto px-6 grid grid-cols-1 md:grid-cols-2 items-center">
-        <div className="max-w-lg text-shadow">
-          <ScrollAnimation animation="fade-in">
-            <h1 className="text-2xl md:text-3xl lg:text-4xl font-semibold text-white mb-4">
-              <span className="bg-blue-900/50 rounded leading-relaxed" style={{
-                boxDecorationBreak: 'clone',
-                WebkitBoxDecorationBreak: 'clone'
-              }}>
-                {t('hero.title', 'The art of negotiation at your service, for a fair deal')}
-              </span>
-            </h1>
-          </ScrollAnimation>
-
-          <ScrollAnimation animation="slide-up" delay={200}>
-            <hr className="w-16 border-t-2 border-navy-950 mb-6" />
-          </ScrollAnimation>
-
-          <ScrollAnimation animation="slide-up" delay={300}>
-            <p className="text-sm md:text-base text-white mb-4">
-              <span className="bg-blue-900/50 rounded leading-relaxed" style={{
-                boxDecorationBreak: 'clone',
-                WebkitBoxDecorationBreak: 'clone'
-              }}>
-                {t('hero.subtitle', 'Our compensation is solely a share of the savings we deliver')}
-              </span>
-            </p>
-          </ScrollAnimation>
-
-          <ScrollAnimation animation="slide-up" delay={400}>
-            <div className="flex flex-wrap gap-4">
-              <Button
-                variant="primary"
-                size="lg"
-                href="/contact"
-                icon={ArrowRight}
-                iconPosition="right"
-                className="bg-navy-950 hover:bg-navy-900"
-              >
-                {t('hero.cta', 'Free Consultation')}
-              </Button>
-              <Button
-                variant="primary"
-                size="lg"
-                href="/services"
-                className="bg-blue-900/50 hover:bg-blue-900/70 border-2 border-white"
-              >
-                {t('hero.secondary', 'View Services')}
-              </Button>
-            </div>
-          </ScrollAnimation>
+    <section className="pt-32 pb-16 bg-white">
+      <div className="container mx-auto px-6 flex flex-col items-center text-center">
+        <div className="relative w-32 h-32 md:w-48 md:h-48 mb-8 hero-smoke">
+          <img
+            src="/hero.jpg"
+            alt="DNego hexagon"
+            className="w-full h-full hero-logo"
+          />
         </div>
-        <div /> {/* Vuoto per mantenere due colonne */}
-      </div>
-
-      {/* Scroll indicator sempre visibile in basso */}
-      <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 animate-bounce">
-        <a
-          href="#why-choose-us"
-          className="flex flex-col items-center text-white hover:opacity-80 transition-opacity"
-        >
-          <span className="text-sm mb-1 bg-blue-900/50 px-1.5 py-0.5 rounded text-center inline-block" style={{
-            boxDecorationBreak: 'clone',
-            WebkitBoxDecorationBreak: 'clone'
-          }}>
-            {t('hero.scroll', 'Scroll')}
-          </span>
-          <svg
-            className="w-6 h-6 bg-blue-900/50 rounded p-0.5"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            viewBox="0 0 24 24"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M12 5v14M5 12l7 7 7-7" />
-          </svg>
-        </a>
+        <ScrollAnimation animation="fade-in">
+          <h1 className="text-2xl md:text-3xl lg:text-4xl font-semibold text-navy-950 mb-4">
+            {t('hero.title', 'The art of negotiation at your service, for a fair deal')}
+          </h1>
+        </ScrollAnimation>
+        <ScrollAnimation animation="slide-up" delay={300}>
+          <p className="text-sm md:text-base text-navy-950 mb-6">
+            {t('hero.subtitle', 'Our compensation is solely a share of the savings we deliver')}
+          </p>
+        </ScrollAnimation>
+        <ScrollAnimation animation="slide-up" delay={400}>
+          <div className="flex flex-wrap gap-4 justify-center">
+            <Button
+              variant="primary"
+              size="lg"
+              href="/contact"
+              icon={ArrowRight}
+              iconPosition="right"
+              className="bg-navy-950 hover:bg-navy-900"
+            >
+              {t('hero.cta', 'Free Consultation')}
+            </Button>
+            <Button
+              variant="outline"
+              size="lg"
+              href="/services"
+              className="border-navy-950 text-navy-950 hover:bg-navy-950 hover:text-white"
+            >
+              {t('hero.secondary', 'View Services')}
+            </Button>
+          </div>
+        </ScrollAnimation>
       </div>
     </section>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -104,3 +104,47 @@
     text-shadow: 0 1px 2px rgba(0,0,0,0.1);
   }
 }
+
+@layer components {
+  .hero-logo {
+    animation: spin3d 10s linear infinite;
+    transform-style: preserve-3d;
+  }
+
+  .hero-smoke::before,
+  .hero-smoke::after {
+    content: '';
+    position: absolute;
+    top: -20%;
+    left: -20%;
+    width: 140%;
+    height: 140%;
+    background: radial-gradient(circle, rgba(0,0,0,0.15), transparent 70%);
+    filter: blur(12px);
+    opacity: 0.4;
+    animation: smoke 6s ease-in-out infinite;
+    pointer-events: none;
+  }
+
+  .hero-smoke::after {
+    animation-delay: -3s;
+  }
+}
+
+@keyframes spin3d {
+  from {
+    transform: rotateY(0deg);
+  }
+  to {
+    transform: rotateY(360deg);
+  }
+}
+
+@keyframes smoke {
+  0%, 100% {
+    transform: translate(-10%, -10%);
+  }
+  50% {
+    transform: translate(10%, 10%);
+  }
+}


### PR DESCRIPTION
## Summary
- Rebuild hero section with centered rotating hexagon logo and animated smoke.
- Replace ribboned copy with dark-blue text and reposition CTAs beneath the emblem.
- Style View Services button with dark-blue outline.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688de66c3ce48324b25f5620f72ac814