### PR TITLE
Animate hexagon in hero

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,5 +1,5 @@
 // Hero.tsx
-import { ArrowRight } from 'lucide-react';
+import { ArrowRight, ArrowDown } from 'lucide-react';
 import Button from '../ui/Button';
 import ScrollAnimation from '../utils/ScrollAnimation';
 import { useLanguage } from '../../contexts/LanguageContext';
@@ -7,13 +7,14 @@ import { useLanguage } from '../../contexts/LanguageContext';
 const Hero: React.FC = () => {
   const { t } = useLanguage();
   return (
-    <section className="pt-32 pb-16 bg-white">
+    <section className="relative pt-32 pb-16 bg-white">
       <div className="container mx-auto px-6 flex flex-col items-center text-center">
-        <div className="relative w-32 h-32 md:w-48 md:h-48 mb-8 hero-smoke">
+        <div className="relative w-28 h-28 md:w-44 md:h-44 mb-8 hero-smoke">
+          <div className="hexagon"></div>
           <img
             src="/hero.jpg"
-            alt="DNego hexagon"
-            className="w-full h-full hero-logo"
+            alt="DNego logo"
+            className="w-full h-full object-contain"
           />
         </div>
         <ScrollAnimation animation="fade-in">
@@ -48,6 +49,10 @@ const Hero: React.FC = () => {
             </Button>
           </div>
         </ScrollAnimation>
+      </div>
+      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex flex-col items-center text-navy-950">
+        <ArrowDown className="w-6 h-6 animate-bounce" />
+        <span className="mt-1 text-sm">{t('hero.scroll', 'Scroll')}</span>
       </div>
     </section>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -106,9 +106,19 @@
 }
 
 @layer components {
-  .hero-logo {
-    animation: spin3d 10s linear infinite;
+  .hexagon {
+    position: absolute;
+    inset: 0;
     transform-style: preserve-3d;
+    animation: spin3d 10s linear infinite;
+  }
+
+  .hexagon::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border: 3px solid #0A2342;
+    clip-path: polygon(25% 6.7%, 75% 6.7%, 100% 50%, 75% 93.3%, 25% 93.3%, 0% 50%);
   }
 
   .hero-smoke::before,


### PR DESCRIPTION
## Summary
- Rotate only the hero hexagon in 3D and keep DN & horse static
- Restore dark-blue bouncing scroll indicator

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688de89a20688324b1fca7756b012611