### PR TITLE
feat: add valuation chat section

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -2,14 +2,15 @@
 import { ArrowRight, ArrowDown } from 'lucide-react';
 import Button from '../ui/Button';
 import ScrollAnimation from '../utils/ScrollAnimation';
+import ValuationChat from './ValuationChat';
 import { useLanguage } from '../../contexts/LanguageContext';
 
 const Hero: React.FC = () => {
   const { t } = useLanguage();
   return (
-    <section className="relative pt-32 pb-16 bg-white">
+    <section className="relative pt-24 pb-32 bg-white">
       <div className="container mx-auto px-6 flex flex-col items-center text-center">
-        <div className="relative w-28 h-28 md:w-44 md:h-44 mb-8 hero-smoke">
+        <div className="relative w-28 h-28 md:w-44 md:h-44 mb-6">
           <div className="hexagon"></div>
           <img
             src="/hero.jpg"
@@ -23,12 +24,12 @@ const Hero: React.FC = () => {
           </h1>
         </ScrollAnimation>
         <ScrollAnimation animation="slide-up" delay={300}>
-          <p className="text-sm md:text-base text-navy-950 mb-6">
+          <p className="text-sm md:text-base text-navy-950 mb-4">
             {t('hero.subtitle', 'Our compensation is solely a share of the savings we deliver')}
           </p>
         </ScrollAnimation>
         <ScrollAnimation animation="slide-up" delay={400}>
-          <div className="flex flex-wrap gap-4 justify-center">
+          <div className="flex flex-wrap gap-4 justify-center mb-6">
             <Button
               variant="primary"
               size="lg"
@@ -49,8 +50,9 @@ const Hero: React.FC = () => {
             </Button>
           </div>
         </ScrollAnimation>
+        <ValuationChat />
       </div>
-      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex flex-col items-center text-navy-950">
+      <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex flex-col items-center text-navy-950">
         <ArrowDown className="w-6 h-6 animate-bounce" />
         <span className="mt-1 text-sm">{t('hero.scroll', 'Scroll')}</span>
       </div>

--- a/src/components/sections/ValuationChat.tsx
+++ b/src/components/sections/ValuationChat.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import Button from '../ui/Button';
+import { useLanguage } from '../../contexts/LanguageContext';
+
+type MessageContent =
+  | { type: 'text'; text: string }
+  | { type: 'image_url'; image_url: { url: string } };
+
+type Message = {
+  role: string;
+  content: MessageContent[];
+};
+
+const ValuationChat: React.FC = () => {
+  const { t } = useLanguage();
+  const [description, setDescription] = useState('');
+  const [image, setImage] = useState<File | null>(null);
+  const [response, setResponse] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([
+    {
+      role: 'system',
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'valuation.system',
+            'Sei un assistente esperto in valutazioni. Chiedi dati integrativi se necessario e poi genera un report sul valore intrinseco del bene o servizio indicato, basandoti sul testo e sull’immagine se presente.'
+          ),
+        },
+      ],
+    },
+  ]);
+
+  const handleSubmit = async () => {
+    await sendToChatGPT(description, image, messages, setMessages, setResponse, setLoading);
+  };
+
+  return (
+    <div className="w-full max-w-xl mx-auto">
+      <div className="bg-white/70 backdrop-blur-sm rounded-lg shadow p-6">
+        <textarea
+          className="w-full border border-navy-200 rounded p-2 mb-4 text-sm"
+          rows={3}
+          placeholder={t('valuation.promptPlaceholder', 'Descrivi il bene o servizio da valutare')}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <input
+          type="file"
+          accept="image/*"
+          className="mb-4"
+          onChange={(e) => setImage(e.target.files?.[0] || null)}
+        />
+        <Button variant="primary" size="lg" onClick={handleSubmit} disabled={loading}>
+          {loading ? t('valuation.loading', 'Valutazione...') : t('valuation.button', 'Valuta')}
+        </Button>
+        {response && (
+          <div className="mt-4 text-left whitespace-pre-wrap text-sm">{response}</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ValuationChat;
+
+// eslint-disable-next-line react-refresh/only-export-components
+export async function sendToChatGPT(
+  description: string,
+  image: File | null,
+  messages: Message[],
+  setMessages: (msgs: Message[]) => void,
+  setResponse: (res: string) => void,
+  setLoading: (val: boolean) => void
+) {
+  const API_KEY = 'INSERISCI_LA_TUA_API_KEY';
+  setLoading(true);
+
+  const userContent: MessageContent[] = [{ type: 'text', text: description }];
+  if (image) {
+    const base64 = await fileToBase64(image);
+    userContent.push({ type: 'image_url', image_url: { url: base64 } });
+  }
+
+  const updatedMessages = [...messages, { role: 'user', content: userContent }];
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4-vision-preview',
+        messages: updatedMessages,
+      }),
+    });
+    const data = await res.json();
+    const assistantMessage = data.choices?.[0]?.message;
+    if (assistantMessage) {
+      setMessages([...updatedMessages, assistantMessage]);
+      setResponse(assistantMessage.content);
+    }
+  } catch {
+    setResponse('Errore nella valutazione.');
+  } finally {
+    setLoading(false);
+  }
+}
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = (error) => reject(error);
+  });
+}

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -24,6 +24,12 @@ const it = {
   'hero.secondary': 'Scopri i Servizi',
   'hero.scroll': 'Scorri',
 
+  // Valuation Chat
+  'valuation.promptPlaceholder': 'Descrivi il bene o servizio da valutare',
+  'valuation.button': 'Valuta',
+  'valuation.loading': 'Valutazione...',
+  'valuation.system': 'Sei un assistente esperto in valutazioni. Chiedi dati integrativi se necessario e poi genera un report sul valore intrinseco del bene o servizio indicato, basandoti sul testo e sull’immagine se presente.',
+
   // Services Preview
   'servicesPreview.title': 'I Nostri Servizi Principali',
   'servicesPreview.subtitle': 'Competenza specializzata nelle negoziazioni dove serve di più',


### PR DESCRIPTION
## Summary
- adjust hero layout: reposition logo, buttons, and scroll hint
- add valuation chat section with GPT-4 Vision support
- add Italian translations for new chat labels

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e03c05d4c83249eb0748c6dcd5076