### PR TITLE
Adjust founder tag position

### DIFF
--- a/src/components/sections/Founder.tsx
+++ b/src/components/sections/Founder.tsx
@@ -19,7 +19,7 @@ const Founder = () => {
                 src="/Profile_Photo.jpg"
                 alt="Alexandru Buruiana, Founder of DNego"
                 className="max-w-md w-full h-auto object-cover md:max-h-[20rem]" />
-              <div className="absolute -bottom-6 -right-6 bg-blue-700 text-white py-2 px-4 rounded-lg shadow-md font-medium">
+              <div className="absolute -bottom-3 -right-6 bg-blue-700 text-white py-2 px-4 rounded-lg shadow-md font-medium">
                 {t('founder.tagline', 'Alexandru Buruiana, Founder')}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- move founder tagline upward to prevent overlap with text

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f627799c08324b14b2f80326e680c