### PR TITLE
Align numbered box styles across sections

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -96,7 +96,7 @@ const About = () => {
             <ScrollAnimation animation="fade-in">
               <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
                 <div className="text-center">
-                  <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-100 text-blue-700 rounded-full mb-4">
+                  <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-600 text-white rounded-full mb-4 shadow-lg">
                     <span className="text-2xl font-bold">1</span>
                   </div>
                   <h3 className="text-xl font-bold mb-3 text-navy-950">
@@ -109,9 +109,9 @@ const About = () => {
                     )}
                   </p>
                 </div>
-                
+
                 <div className="text-center">
-                  <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-100 text-blue-700 rounded-full mb-4">
+                  <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-600 text-white rounded-full mb-4 shadow-lg">
                     <span className="text-2xl font-bold">2</span>
                   </div>
                   <h3 className="text-xl font-bold mb-3 text-navy-950">
@@ -124,9 +124,9 @@ const About = () => {
                     )}
                   </p>
                 </div>
-                
+
                 <div className="text-center">
-                  <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-100 text-blue-700 rounded-full mb-4">
+                  <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-600 text-white rounded-full mb-4 shadow-lg">
                     <span className="text-2xl font-bold">3</span>
                   </div>
                   <h3 className="text-xl font-bold mb-3 text-navy-950">

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -219,7 +219,7 @@ const Services = () => {
                       <div className="space-y-6">
                         <div>
                           <h4 className="font-bold text-red-700 mb-2 flex items-center">
-                            <span className="w-6 h-6 bg-red-100 text-red-700 rounded-full flex items-center justify-center text-sm font-bold mr-2">1</span>
+                            <span className="w-8 h-8 bg-gradient-to-br from-red-500 to-red-600 text-white rounded-full flex items-center justify-center text-sm font-bold mr-2">1</span>
                             {t('services.challengeLabel', 'Challenge:')}
                           </h4>
                           <p className="text-gray-600 ml-8">
@@ -232,7 +232,7 @@ const Services = () => {
 
                         <div>
                           <h4 className="font-bold text-blue-700 mb-2 flex items-center">
-                            <span className="w-6 h-6 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center text-sm font-bold mr-2">2</span>
+                            <span className="w-8 h-8 bg-gradient-to-br from-blue-500 to-blue-600 text-white rounded-full flex items-center justify-center text-sm font-bold mr-2">2</span>
                             {t('services.solutionLabel', 'Solution:')}
                           </h4>
                           <p className="text-gray-600 ml-8">
@@ -245,7 +245,7 @@ const Services = () => {
 
                         <div>
                           <h4 className="font-bold text-green-700 mb-2 flex items-center">
-                            <span className="w-6 h-6 bg-green-100 text-green-700 rounded-full flex items-center justify-center text-sm font-bold mr-2">3</span>
+                            <span className="w-8 h-8 bg-gradient-to-br from-green-500 to-green-600 text-white rounded-full flex items-center justify-center text-sm font-bold mr-2">3</span>
                             {t('services.resultLabel', 'Result:')}
                           </h4>
                           <p className="text-gray-600 ml-8">


### PR DESCRIPTION
## Summary
- Apply gradient styling to numbered circles in About page mission section to match home design
- Update Services page case study numbers to use consistent gradient number badges

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `python backend_test.py` *(fails: No module named 'requests'; build failed; yarn lock file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7151bb3288324b4eccf25092a7ad2