### PR TITLE
fix: properly close contact heading

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -98,10 +98,12 @@ const Contact = () => {
             {/* Contact Info */}
             <ScrollAnimation animation="slide-up">
               <div className="bg-navy-950 text-white p-8 lg:p-12 rounded-lg shadow-xl h-full">
-                <h2 className="text-2xl font-bold text-white">
-                  {t('contact.getInTouch', 'Get In Touch')}
-                </h2>
-                <div className="w-16 h-1 bg-gradient-to-r from-blue-500 to-blue-600 rounded-full mb-8" />
+                <div className="mb-8">
+                  <h2 className="text-2xl font-bold text-white">
+                    {t('contact.getInTouch', 'Get In Touch')}
+                  </h2>
+                  <div className="w-16 h-1 bg-gradient-to-r from-blue-500 to-blue-600 rounded-full mt-2" />
+                </div>
 
                 <div className="space-y-6 mb-12">
                   <div className="flex items-start">


### PR DESCRIPTION
## Summary
- wrap Contact page heading and decorative line in a container
- ensures JSX tags properly closed

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a95e3ccc0c8324a5c29e316028d4cd