### PR TITLE
Remove compensation tagline and add Italian translations

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -31,12 +31,6 @@ const Hero: React.FC = () => {
             <div className="w-16 h-1 bg-gradient-to-r from-blue-400 to-blue-600 rounded-full mb-8" />
           </ScrollAnimation>
 
-          <ScrollAnimation animation="slide-up" delay={400}>
-            <p className="text-xl md:text-2xl text-navy-950 mb-10 leading-relaxed font-light">
-              {t('hero.subtitle', 'Our compensation is solely a share of the savings we deliver')}
-            </p>
-          </ScrollAnimation>
-
           <ScrollAnimation animation="slide-up" delay={500}>
             <div className="flex flex-col sm:flex-row gap-4 mb-8">
               <Button

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -19,7 +19,9 @@ const it = {
 
   // Hero
   'hero.title': 'L\'arte della negoziazione al tuo servizio, per un accordo equo',
-  'hero.subtitle': 'Il nostro compenso è una percentuale dei risparmi che ti facciamo guadagnare',
+  'hero.badge': 'Consulenza senza rischi al 100%',
+  'hero.feature1': 'Nessun costo iniziale',
+  'hero.feature2': 'Paghi solo se risparmi',
   'hero.cta': 'Consulenza Gratuita',
   'hero.secondary': 'Scopri i Servizi',
   'hero.scroll': 'Scorri',
@@ -89,6 +91,11 @@ const it = {
   'contact.course1': 'Tecniche Avanzate di Negoziazione',
   'contact.course2': 'Negoziare per Project Manager',
   'contact.course3': 'Gestione e Strategia dei Fornitori',
+  'contact.why.title': 'Perché iniziare con noi?',
+  'contact.why.free': 'Consulenza 100% gratuita',
+  'contact.why.risk': 'Nessun costo o rischio iniziale',
+  'contact.why.expert': 'Analisi di negoziazione da esperti',
+  'contact.why.results': 'Paghi solo per i risultati',
   'contact.formTitle': 'Invia un Messaggio',
   'contact.success': 'Grazie per il messaggio! Ti ricontatteremo a breve.',
   'contact.nameLabel': 'Nome Completo',


### PR DESCRIPTION
## Summary
- remove compensation subtitle from hero section
- translate hero badge and payment feature texts into Italian
- add Italian translations for contact page callouts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaca06fb048324977490a9911401dc