### PR TITLE
Remove hero compensation tagline and localize risk-free phrases

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -32,12 +32,6 @@ const Hero: React.FC = () => {
           </ScrollAnimation>
 
           <ScrollAnimation animation="slide-up" delay={400}>
-            <p className="text-xl md:text-2xl text-navy-950 mb-10 leading-relaxed font-light">
-              {t('hero.subtitle', 'Our compensation is solely a share of the savings we deliver')}
-            </p>
-          </ScrollAnimation>
-
-          <ScrollAnimation animation="slide-up" delay={500}>
             <div className="flex flex-col sm:flex-row gap-4 mb-8">
               <Button
                 variant="primary"
@@ -60,7 +54,7 @@ const Hero: React.FC = () => {
             </div>
           </ScrollAnimation>
 
-          <ScrollAnimation animation="fade-in" delay={600}>
+          <ScrollAnimation animation="fade-in" delay={500}>
             <div className="flex items-center gap-6 text-navy-700">
               <div className="flex items-center gap-2">
                 <CheckCircle className="w-5 h-5 text-green-500" />

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -19,10 +19,12 @@ const it = {
 
   // Hero
   'hero.title': 'L\'arte della negoziazione al tuo servizio, per un accordo equo',
-  'hero.subtitle': 'Il nostro compenso è una percentuale dei risparmi che ti facciamo guadagnare',
   'hero.cta': 'Consulenza Gratuita',
   'hero.secondary': 'Scopri i Servizi',
   'hero.scroll': 'Scorri',
+  'hero.badge': 'Consulenza 100% senza rischi',
+  'hero.feature1': 'Nessun costo iniziale',
+  'hero.feature2': 'Paghi solo se risparmi',
 
   // Services Preview
   'servicesPreview.title': 'I Nostri Servizi Principali',


### PR DESCRIPTION
## Summary
- Remove compensation subtitle from the hero section to clean up the landing page.
- Add Italian translations for the hero badge and risk-free feature text.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aacffdb3008324aaddc52167babab1