### PR TITLE
Make service type optional in contact form

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { Facebook, Twitter, Linkedin, Instagram, Mail, Phone, MapPin, ArrowRight, Heart } from 'lucide-react';
+import { Facebook, Linkedin, Instagram, Mail, Phone, MapPin, ArrowRight, Heart } from 'lucide-react';
 import { useLanguage } from '../../contexts/LanguageContext';
 
 const Footer = () => {

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -173,10 +173,9 @@ const Contact = () => {
 
                   <div>
                     <label className="block text-sm font-semibold text-navy-950 mb-2">
-                      {t('contact.form.service', 'Type of Negotiation')} *
+                      {t('contact.form.service', 'Type of Negotiation')}
                     </label>
                     <select
-                      required
                       className="w-full px-4 py-4 border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-300 bg-white hover:border-gray-300"
                     >
                       <option value="">{t('contact.form.selectService', 'Select a service...')}</option>


### PR DESCRIPTION
## Summary
- Remove required attribute from service type selector so requests can be sent without specifying a service
- Clean up unused Twitter icon import in footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af17af633c8324aa7f34655115ab4e