### PR TITLE
Remove privacy consent requirement from contact forms

### DIFF
--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -197,22 +197,6 @@ const Contact = () => {
                       placeholder={t('contact.form.messagePlaceholder', 'Please describe your negotiation situation, goals, and any relevant details...')}
                     />
                   </div>
-
-                  <div className="flex items-center gap-3">
-                    <input
-                      type="checkbox"
-                      id="consent"
-                      required
-                      className="w-5 h-5 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
-                    />
-                    <label htmlFor="consent" className="text-sm text-gray-600">
-                      {t('contact.form.consent', 'I agree to receive communications and understand that my information will be used according to the')}{' '}
-                      <a href="/privacy" className="text-blue-600 hover:text-blue-700 underline">
-                        {t('contact.form.privacy', 'Privacy Policy')}
-                      </a>
-                    </label>
-                  </div>
-
                   <Button
                     type="submit"
                     variant="primary"

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -102,10 +102,6 @@ const it = {
   'contact.messageLabel': 'Il tuo Messaggio',
   'contact.messageInvalid': 'Inserisci il messaggio',
   'contact.messagePlaceholder': 'Come possiamo aiutarti?',
-  'contact.privacyInvalid': 'Devi accettare la privacy policy',
-  'contact.privacyText': 'Accetto la',
-  'contact.privacyPolicy': 'privacy policy',
-  'contact.privacyContinue': 'e acconsento a essere contattato per la mia richiesta.',
   'contact.submit': 'Invia Messaggio',
   'contact.sending': 'Invio...',
 

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -293,32 +293,6 @@ const Contact = () => {
                       required
                     />
                   </div>
-
-                  <div className="flex items-center mb-8">
-                    <input
-                      type="checkbox"
-                      id="privacy"
-                      className="h-4 w-4 text-blue-700 border-gray-300 rounded focus:ring-blue-700"
-                      onInvalid={(e) =>
-                        e.currentTarget.setCustomValidity(
-                          t('contact.privacyInvalid', 'You must agree to the privacy policy')
-                        )
-                      }
-                      onInput={(e) => e.currentTarget.setCustomValidity("")}
-                      required
-                    />
-                    <label
-                      htmlFor="privacy"
-                      className="ml-2 block text-sm text-gray-700"
-                    >
-                      {t('contact.privacyText', 'I agree to the ')}{" "}
-                      <a href="/privacy" className="text-blue-700 underline">
-                        {t('contact.privacyPolicy', 'privacy policy')}
-                      </a>{" "}
-                      {t('contact.privacyContinue', 'and consent to being contacted regarding my inquiry.')}
-                    </label>
-                  </div>
-
                   <Button
                     variant="primary"
                     size="lg"


### PR DESCRIPTION
## Summary
- drop mandatory privacy checkbox from contact page to streamline message submissions
- remove consent checkbox from contact section and clean up Italian translations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af1b3a8a008324be9264e9b65212e2