### PR TITLE
Remove negotiation type selector from contact form

### DIFF
--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -173,21 +173,6 @@ const Contact = () => {
 
                   <div>
                     <label className="block text-sm font-semibold text-navy-950 mb-2">
-                      {t('contact.form.service', 'Type of Negotiation')}
-                    </label>
-                    <select
-                      className="w-full px-4 py-4 border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-300 bg-white hover:border-gray-300"
-                    >
-                      <option value="">{t('contact.form.selectService', 'Select a service...')}</option>
-                      <option value="real-estate">{t('servicesPreview.realEstate.title', 'Real Estate Negotiation')}</option>
-                      <option value="salary">{t('servicesPreview.salary.title', 'Salary & Benefits Negotiation')}</option>
-                      <option value="business">{t('servicesPreview.consulting.title', 'Business Consultation Services')}</option>
-                      <option value="other">{t('contact.form.other', 'Other')}</option>
-                    </select>
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-semibold text-navy-950 mb-2">
                       {t('contact.form.message', 'Tell us about your situation')} *
                     </label>
                     <textarea


### PR DESCRIPTION
## Summary
- drop "Type of Negotiation" dropdown from the contact form so clients only provide message and personal details

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af1cda725c832491a7b9189c82a534