### PR TITLE
Localize home page sections for Italian

### DIFF
--- a/src/components/sections/Founder.tsx
+++ b/src/components/sections/Founder.tsx
@@ -29,15 +29,15 @@ const Founder = () => {
                   <div className="relative inline-block">
                     <img
                       src="/Profile_Photo.jpg"
-                      alt="Alexandru Buruiana, Founder of DNego"
+                      alt={t('founder.imageAlt', 'Alexandru Buruiana, Founder of DNego')}
                       className="w-64 h-64 object-cover rounded-2xl shadow-xl mx-auto"
                     />
                     <div className="absolute -bottom-4 -right-4 bg-gradient-to-r from-blue-600 to-blue-700 text-white py-3 px-6 rounded-xl shadow-lg">
-                      <div className="text-sm font-semibold">Founder & Lead Negotiator</div>
+                      <div className="text-sm font-semibold">{t('founder.role', 'Founder & Lead Negotiator')}</div>
                     </div>
                   </div>
                   <h3 className="text-3xl font-bold text-navy-950 mt-8 mb-2">Alexandru Buruiana</h3>
-                  <p className="text-blue-600 font-semibold text-lg">Mechanical Engineer & Negotiation Expert</p>
+                  <p className="text-blue-600 font-semibold text-lg">{t('founder.titleRole', 'Mechanical Engineer & Negotiation Expert')}</p>
                 </div>
               </div>
 
@@ -113,7 +113,7 @@ const Founder = () => {
                   </div>
                 </div>
                 <div>
-                  <h4 className="text-xl font-bold text-navy-950 mb-2">My Journey in Negotiation</h4>
+                  <h4 className="text-xl font-bold text-navy-950 mb-2">{t('founder.journeyTitle', 'My Journey in Negotiation')}</h4>
                   <div className="w-16 h-1 bg-gradient-to-r from-blue-500 to-blue-600 rounded-full" />
                 </div>
               </div>
@@ -151,7 +151,7 @@ const Founder = () => {
                   </div>
                 </div>
                 <div>
-                  <h4 className="text-xl font-bold text-navy-950 mb-2">My Philosophy</h4>
+                  <h4 className="text-xl font-bold text-navy-950 mb-2">{t('founder.philosophyTitle', 'My Philosophy')}</h4>
                   <div className="w-16 h-1 bg-gradient-to-r from-purple-500 to-purple-600 rounded-full" />
                 </div>
               </div>

--- a/src/components/sections/WhyChooseUs.tsx
+++ b/src/components/sections/WhyChooseUs.tsx
@@ -25,9 +25,9 @@ const features = [
 ];
 
 const stats = [
-  { number: '50%', label: 'Your Share of Savings', icon: TrendingUp },
-  { number: '100%', label: 'Success-Based Fees', icon: Award },
-  { number: '5+', label: 'Years Experience', icon: Users2 },
+  { number: '50%', label: ['choose.stats1', 'Your Share of Savings'], icon: TrendingUp },
+  { number: '100%', label: ['choose.stats2', 'Success-Based Fees'], icon: Award },
+  { number: '5+', label: ['choose.stats3', 'Years Experience'], icon: Users2 },
 ];
 
 const WhyChooseUs = () => {
@@ -61,7 +61,7 @@ const WhyChooseUs = () => {
                 <div className="text-4xl md:text-5xl font-bold text-navy-950 mb-2 group-hover:text-blue-700 transition-colors duration-300">
                   {stat.number}
                 </div>
-                <div className="text-gray-600 font-medium">{stat.label}</div>
+                <div className="text-gray-600 font-medium">{t(stat.label[0], stat.label[1])}</div>
               </div>
             </ScrollAnimation>
           ))}

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -46,6 +46,9 @@ const it = {
   // Why Choose Us
   'choose.title': 'Perché Sceglierci',
   'choose.subtitle': 'Uniamo competenza, trasparenza e un approccio senza rischi per offrirti valore eccezionale',
+  'choose.stats1': 'La tua quota di risparmi',
+  'choose.stats2': 'Commissioni basate sui risultati',
+  'choose.stats3': 'Anni di esperienza',
   'choose.feature1.title': 'Modello 100% senza rischi',
   'choose.feature1.desc': 'Abbiamo successo solo quando lo hai anche tu. Paghi soltanto se riduciamo i costi (tratteniamo il 50% dei risparmi).',
   'choose.feature2.title': 'Fiducia e Trasparenza',
@@ -78,7 +81,11 @@ const it = {
   // Founder
   'founder.section': 'Il Fondatore',
   'founder.about': 'Riguardo al Fondatore',
-  'founder.tagline': 'Alexandru Buruiana, Fondatore',
+  'founder.imageAlt': 'Alexandru Buruiana, fondatore di DNego',
+  'founder.role': 'Fondatore e Negoziatore Principale',
+  'founder.titleRole': 'Ingegnere Meccanico e Esperto di Negoziazione',
+  'founder.journeyTitle': 'Il Mio Percorso nella Negoziazione',
+  'founder.philosophyTitle': 'La Mia Filosofia',
   'founder.bio1': 'Sono un Ingegnere Meccanico specializzato in energia, e da sempre credo nell\'importanza di riconoscere e difendere il giusto valore delle cose. Ho scoperto che la negoziazione è la mia vera passione grazie all\'energia e all\'entusiasmo che sento ogni volta che mi trovo a pattuire, cercare un accordo, trovare un punto d\'incontro.',
   'founder.bio2': 'Negli anni ho affinato questa attitudine lavorando negli uffici acquisti di diverse aziende, trattando materie prime e servizi, ma presto ho capito che per me non era solo un lavoro: era un modo di vivere, guidato da principi come l\'equità, il rispetto reciproco e la ricerca di soluzioni che creano valore per tutti.',
   'founder.bio3': 'Con il tempo, questo desiderio di giustizia e di equilibrio mi ha portato oltre l\'ambito aziendale, ad aiutare anche persone estranee al mio lavoro: amici, familiari, conoscenti e chiunque avesse bisogno di un supporto in una trattativa importante.',


### PR DESCRIPTION
## Summary
- Translate home page "Why Choose Us" stats and hook them into the i18n system.
- Localize the founder profile with translated role, profession, and section headings.
- Add corresponding Italian strings for stats and founder details in the i18n file.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b854ebbb8c83228fc1c93164397374